### PR TITLE
Drop jwt-simple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,12 +37,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,7 +265,6 @@ dependencies = [
  "futures",
  "getrandom",
  "js-sys",
- "jwt-simple",
  "nom",
  "p384",
  "rand",
@@ -325,32 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bindgen"
-version = "0.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
-dependencies = [
- "bitflags 2.5.0",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "binstring"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,17 +328,6 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "blake3"
@@ -413,41 +369,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "boring"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8259fc1ea91894a550190683fbcda307d1ef85f2875d93a2b1ab3cab58b62fea"
-dependencies = [
- "bitflags 2.5.0",
- "boring-sys",
- "foreign-types",
- "libc",
- "once_cell",
-]
-
-[[package]]
-name = "boring-sys"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace69f2e0d89d2c5e0874efe47f46259ff794fe8cbddfca72132c817611ad471"
-dependencies = [
- "bindgen",
- "cmake",
- "fs_extra",
- "fslock",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -460,15 +385,6 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -509,37 +425,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "coarsetime"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
-dependencies = [
- "libc",
- "wasix",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -654,12 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-codecs"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,16 +582,6 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
-dependencies = [
- "ct-codecs",
- "getrandom",
 ]
 
 [[package]]
@@ -841,55 +710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1040,12 +866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1113,30 +933,6 @@ name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "hmac-sha1-compact"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9d405ec732fa3fcde87264e54a32a84956a377b3e3107de96e59b798c84a7"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "hmac-sha512"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
 dependencies = [
  "digest",
 ]
@@ -1270,47 +1066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt-simple"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094661f5aad510abe2658bff20409e89046b753d9dc2d4007f5c100b6d982ba0"
-dependencies = [
- "anyhow",
- "binstring",
- "blake2b_simd",
- "boring",
- "coarsetime",
- "ct-codecs",
- "ed25519-compact",
- "hmac-sha1-compact",
- "hmac-sha256",
- "hmac-sha512",
- "k256",
- "p256",
- "p384",
- "rand",
- "serde",
- "serde_json",
- "superboring",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,37 +1079,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libloading"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1491,23 +1221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1602,18 +1314,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
 
 [[package]]
 name = "p384"
@@ -1657,12 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,17 +1392,6 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.0.2",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -1935,37 +1618,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -2101,12 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,12 +1811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,23 +1827,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
-name = "superboring"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbde97f499e51ef384f585dc8f8fb6a9c3a71b274b8d12469b516758e6540607"
-dependencies = [
- "getrandom",
- "hmac-sha256",
- "hmac-sha512",
- "rand",
- "rsa",
-]
-
-[[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2566,15 +2197,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasix"
-version = "0.12.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
-dependencies = [
- "wasi",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,7 @@ categories = ["filesystems", "cryptography", "storage"]
 
 [features]
 default = ["banyan-api", "pem", "strict", "tomb-compat"]
-banyan-api = [
-  "async-trait",
-  "jwt-simple",
-  "reqwest",
-  "serde",
-  "serde_json",
-  "url",
-]
+banyan-api = ["async-trait", "reqwest", "serde", "serde_json", "url"]
 pem = ["p384/pem", "p384/pkcs8"]
 strict = []
 tomb-compat = ["banyan-api"]
@@ -63,10 +56,6 @@ slab = "^0.4"
 # unix milliseconds, displaying is for other libraries so should drop this
 time = "^0.3"
 
-# TODO: we have most of what jwt-simple handles in our own crypto code which we
-# really don't need and it doesn't quite match our needs. We can pull this out
-# and reduce the scope of our library.
-jwt-simple = { version = "^0.12", optional = true }
 reqwest = { version = "^0.11", default-features = false, optional = true, features = [
   "multipart",
   "json",

--- a/src/api/client/platform_token.rs
+++ b/src/api/client/platform_token.rs
@@ -1,11 +1,18 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_std::sync::RwLock;
-use jwt_simple::prelude::*;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use rand::RngCore;
 use time::OffsetDateTime;
 
 use crate::api::client::{ExpiringToken, PLATFORM_AUDIENCE};
 use crate::codec::crypto::SigningKey;
+
+const CLOCK_LEEWAY: Duration = Duration::from_secs(30);
+
+const TOKEN_LIFETIME: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Default)]
 pub(crate) struct PlatformToken(Arc<RwLock<Option<ExpiringToken>>>);
@@ -25,23 +32,41 @@ impl PlatformToken {
 
         let verifying_key = key.verifying_key();
         let fingerprint = crate::api::client::utils::api_fingerprint_key(&verifying_key);
-        let expiration = OffsetDateTime::now_utc() + std::time::Duration::from_secs(300);
 
-        // todo(sstelfox): this jwt library is definitely an integration pain point, we have all
-        // the primives already in this crate, we should just use them and correctly construct the
-        // JWTs ourselves.
-        let current_ts = Clock::now_since_epoch();
-        let mut claims = Claims::create(Duration::from_secs(330))
-            .with_audience(PLATFORM_AUDIENCE)
-            .with_subject(id)
-            .invalid_before(current_ts - Duration::from_secs(30));
+        let current_time = OffsetDateTime::now_utc();
 
-        claims.create_nonce();
-        claims.issued_at = Some(current_ts);
+        let not_before = current_time - CLOCK_LEEWAY;
+        let expiration = OffsetDateTime::now_utc() + TOKEN_LIFETIME;
+        let not_after = expiration + CLOCK_LEEWAY;
 
-        let mut jwt_key = ES384KeyPair::from_bytes(&key.to_bytes())?;
-        jwt_key = jwt_key.with_key_id(&fingerprint);
-        let token = jwt_key.sign(claims)?;
+        //let token = jwt_key.sign(claims)?;
+
+        let mut rng = crate::utils::crypto_rng();
+        let mut nonce_bytes = [0u8; 24];
+        rng.fill_bytes(&mut nonce_bytes);
+        let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+
+        let jwt_hdr =
+            serde_json::json!({"alg": "ES384", "kid": fingerprint, "typ": "JWT"}).to_string();
+        let jwt_hdr_b64 = URL_SAFE_NO_PAD.encode(jwt_hdr.as_bytes());
+
+        let jwt_claim = serde_json::json!({
+            "iat": current_time.unix_timestamp(),
+            "exp": not_after.unix_timestamp(),
+            "nbf": not_before.unix_timestamp(),
+            "sub": id,
+            "aud": PLATFORM_AUDIENCE,
+            "nonce": nonce,
+        })
+        .to_string();
+        let jwt_claim_b64 = URL_SAFE_NO_PAD.encode(jwt_claim.as_bytes());
+
+        let signed_data = format!("{}.{}", jwt_hdr_b64, jwt_claim_b64);
+        let signature_bytes = key.sign(&mut rng, signed_data.as_bytes()).to_vec();
+        let signature = URL_SAFE_NO_PAD.encode(signature_bytes.as_slice());
+
+        // todo generate signature from private key, base64 encode it
+        let token = format!("{}.{}", signed_data, signature);
 
         tracing::debug!("generated new platform token");
 
@@ -56,7 +81,5 @@ impl PlatformToken {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum PlatformTokenError {
-    #[error("failed to generate token for platform platform: {0}")]
-    JwtSimpleError(#[from] jwt_simple::Error),
-}
+#[error("platform token error")]
+pub struct PlatformTokenError;

--- a/src/api/client/platform_token.rs
+++ b/src/api/client/platform_token.rs
@@ -1,18 +1,10 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_std::sync::RwLock;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine;
-use rand::RngCore;
-use time::OffsetDateTime;
 
+use crate::api::client::utils::create_jwt;
 use crate::api::client::{ExpiringToken, PLATFORM_AUDIENCE};
 use crate::codec::crypto::SigningKey;
-
-const CLOCK_LEEWAY: Duration = Duration::from_secs(30);
-
-const TOKEN_LIFETIME: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Default)]
 pub(crate) struct PlatformToken(Arc<RwLock<Option<ExpiringToken>>>);
@@ -30,43 +22,8 @@ impl PlatformToken {
             }
         }
 
-        let verifying_key = key.verifying_key();
-        let fingerprint = crate::api::client::utils::api_fingerprint_key(&verifying_key);
-
-        let current_time = OffsetDateTime::now_utc();
-
-        let not_before = current_time - CLOCK_LEEWAY;
-        let expiration = OffsetDateTime::now_utc() + TOKEN_LIFETIME;
-        let not_after = expiration + CLOCK_LEEWAY;
-
-        //let token = jwt_key.sign(claims)?;
-
         let mut rng = crate::utils::crypto_rng();
-        let mut nonce_bytes = [0u8; 24];
-        rng.fill_bytes(&mut nonce_bytes);
-        let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
-
-        let jwt_hdr =
-            serde_json::json!({"alg": "ES384", "kid": fingerprint, "typ": "JWT"}).to_string();
-        let jwt_hdr_b64 = URL_SAFE_NO_PAD.encode(jwt_hdr.as_bytes());
-
-        let jwt_claim = serde_json::json!({
-            "iat": current_time.unix_timestamp(),
-            "exp": not_after.unix_timestamp(),
-            "nbf": not_before.unix_timestamp(),
-            "sub": id,
-            "aud": PLATFORM_AUDIENCE,
-            "nonce": nonce,
-        })
-        .to_string();
-        let jwt_claim_b64 = URL_SAFE_NO_PAD.encode(jwt_claim.as_bytes());
-
-        let signed_data = format!("{}.{}", jwt_hdr_b64, jwt_claim_b64);
-        let signature_bytes = key.sign(&mut rng, signed_data.as_bytes()).to_vec();
-        let signature = URL_SAFE_NO_PAD.encode(signature_bytes.as_slice());
-
-        // todo generate signature from private key, base64 encode it
-        let token = format!("{}.{}", signed_data, signature);
+        let (token, expiration) = create_jwt(&mut rng, id, PLATFORM_AUDIENCE, key);
 
         tracing::debug!("generated new platform token");
 

--- a/src/api/client/storage_host_auth.rs
+++ b/src/api/client/storage_host_auth.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use jwt_simple::prelude::*;
 use reqwest::Url;
-use time::OffsetDateTime;
 
-use crate::api::client::utils::api_fingerprint_key;
+use crate::api::client::utils::create_jwt;
 use crate::api::client::{ApiClient, ApiError, ExpiringToken, STORAGE_HOST_AUDIENCE};
 use crate::api::platform::account::get_storage_grant;
 use crate::api::storage_host::auth::{register_grant, who_am_i};
@@ -31,31 +29,8 @@ impl StorageHostAuth {
         account_id: &str,
         key: &Arc<SigningKey>,
     ) -> Result<String, StorageTokenError> {
-        let verifying_key = key.verifying_key();
-        let fingerprint = api_fingerprint_key(&verifying_key);
-
-        //let paired_id = format!("{account_id}@{}", fingerprint);
-        let expiration = OffsetDateTime::now_utc() + std::time::Duration::from_secs(300);
-
-        // todo(sstelfox): this jwt library is definitely an integration pain point, we have all
-        // the primives already in this crate, we should just use them and correctly construct the
-        // JWTs ourselves.
-        let current_ts = Clock::now_since_epoch();
-        let mut claims = Claims::create(Duration::from_secs(330))
-            // note(sstelfox): Audience needs to be the storage host service name which we don't
-            // track now. For now the audience verification is disable and we rely on the
-            // public/private keypairs exclusively for matching the authorizations.
-            .with_audience(STORAGE_HOST_AUDIENCE)
-            // note(sstelfox): I don't believe we're using the subject...
-            .with_subject(account_id)
-            .invalid_before(current_ts - Duration::from_secs(30));
-
-        claims.create_nonce();
-        claims.issued_at = Some(current_ts);
-
-        let mut jwt_key = ES384KeyPair::from_bytes(&key.to_bytes())?;
-        jwt_key = jwt_key.with_key_id(&fingerprint);
-        let token = jwt_key.sign(claims)?;
+        let mut rng = crate::utils::crypto_rng();
+        let (token, expiration) = create_jwt(&mut rng, account_id, STORAGE_HOST_AUDIENCE, key);
 
         self.active_tokens.insert(
             storage_host_url.clone(),
@@ -180,9 +155,6 @@ impl StorageHostAuth {
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageTokenError {
-    #[error("failed to generate token for a storage host: {0}")]
-    JwtSimple(#[from] jwt_simple::Error),
-
     #[error("failed to retrieve storage grant from platform")]
     PlatformGrant,
 

--- a/src/api/client/utils/mod.rs
+++ b/src/api/client/utils/mod.rs
@@ -2,13 +2,23 @@ mod vec_stream;
 
 pub(crate) use vec_stream::vec_to_pinned_stream;
 
+use std::time::Duration;
+
 use async_std::prelude::*;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use blake3::Hasher;
 use bytes::{Bytes, BytesMut};
+use elliptic_curve::rand_core::CryptoRngCore;
+use time::OffsetDateTime;
 
-use crate::codec::crypto::VerifyingKey;
+use crate::codec::crypto::{SigningKey, VerifyingKey};
+
+const CLOCK_LEEWAY: Duration = Duration::from_secs(30);
 
 const FINGERPRINT_SIZE: usize = 20;
+
+const TOKEN_LIFETIME: Duration = Duration::from_secs(300);
 
 /// The API uses a truncated blake3 hash for key identification. This provides a convenient method
 /// to generate matching one from a public key.
@@ -47,4 +57,49 @@ where
     }
 
     Ok(bytes_mut.freeze())
+}
+
+/// Creates a JWT token to authenticated against the APIs. There are crates that perform this but
+/// they are more general and have a much larger attack surface (as well as dependencies with known
+/// vulnerabilities). This is a minimal implementation that generates exactly what we need.
+pub(crate) fn create_jwt(
+    rng: &mut impl CryptoRngCore,
+    subject: &str,
+    audience: &str,
+    key: &SigningKey,
+) -> (String, OffsetDateTime) {
+    let verifying_key = key.verifying_key();
+    let fingerprint = crate::api::client::utils::api_fingerprint_key(&verifying_key);
+
+    let current_time = OffsetDateTime::now_utc();
+
+    let not_before = current_time - CLOCK_LEEWAY;
+    let expiration = OffsetDateTime::now_utc() + TOKEN_LIFETIME;
+    let not_after = expiration + CLOCK_LEEWAY;
+
+    let mut nonce_bytes = [0u8; 24];
+    rng.fill_bytes(&mut nonce_bytes);
+    let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+
+    let jwt_hdr = serde_json::json!({"alg": "ES384", "kid": fingerprint, "typ": "JWT"}).to_string();
+    let jwt_hdr_b64 = URL_SAFE_NO_PAD.encode(jwt_hdr.as_bytes());
+
+    let jwt_claim = serde_json::json!({
+        "iat": current_time.unix_timestamp(),
+        "exp": not_after.unix_timestamp(),
+        "nbf": not_before.unix_timestamp(),
+        "sub": subject,
+        "aud": audience,
+        "nonce": nonce,
+    })
+    .to_string();
+    let jwt_claim_b64 = URL_SAFE_NO_PAD.encode(jwt_claim.as_bytes());
+
+    let signed_data = format!("{}.{}", jwt_hdr_b64, jwt_claim_b64);
+    let signature_bytes = key.sign(rng, signed_data.as_bytes()).to_vec();
+    let signature = URL_SAFE_NO_PAD.encode(signature_bytes.as_slice());
+
+    let token = format!("{}.{}", signed_data, signature);
+
+    (token, expiration)
 }

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -37,6 +37,10 @@ impl Signature {
 
         Ok((remaining, signature))
     }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.inner.to_vec()
+    }
 }
 
 impl From<ecdsa::Signature<NistP384>> for Signature {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(feature = "banyan-api")]


### PR DESCRIPTION
Replaces jwt-simple with a direct token generator using our own internal crypto primitives. This has the knock on effect of removing some very large dependencies and some that had unpatched vulnerabilities. This also drops our WASM bundled size by 23%. Feels good.