### PR TITLE
feat(N/A): Convert BanyanFS to use winnow over nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,9 +2845,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.4.11"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,9 +2845,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.3.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,6 @@ dependencies = [
  "getrandom",
  "js-sys",
  "jwt-simple",
- "nom",
  "p384",
  "rand",
  "rand_chacha",
@@ -2846,9 +2845,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,9 +2845,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "^0.22"
 bytes = "^1"
 # TODO: we only minimally use UUID and only for the v7 version, we can hand generate those and save the dependency
 uuid = { version = "^1", features = ["v7", "serde"] }
-winnow = "0.5"
+winnow = "0.6"
 crdts = { version = "^7", default-features = false, features = [
   "merkle",
   "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "^0.22"
 bytes = "^1"
 # TODO: we only minimally use UUID and only for the v7 version, we can hand generate those and save the dependency
 uuid = { version = "^1", features = ["v7", "serde"] }
-winnow = "0.3"
+winnow = "0.4"
 crdts = { version = "^7", default-features = false, features = [
   "merkle",
   "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,7 @@ base64 = "^0.22"
 bytes = "^1"
 # TODO: we only minimally use UUID and only for the v7 version, we can hand generate those and save the dependency
 uuid = { version = "^1", features = ["v7", "serde"] }
-# TODO: transitioning from nom to winnow, finish it up and remove nom
-nom = "^7"
-winnow = "^0.6"
+winnow = "0.3"
 crdts = { version = "^7", default-features = false, features = [
   "merkle",
   "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "^0.22"
 bytes = "^1"
 # TODO: we only minimally use UUID and only for the v7 version, we can hand generate those and save the dependency
 uuid = { version = "^1", features = ["v7", "serde"] }
-winnow = "0.4"
+winnow = "0.5"
 crdts = { version = "^7", default-features = false, features = [
   "merkle",
   "num",

--- a/src/codec/crypto/access_key.rs
+++ b/src/codec/crypto/access_key.rs
@@ -109,7 +109,7 @@ impl From<[u8; ACCESS_KEY_LENGTH]> for AccessKey {
 #[derive(Debug, thiserror::Error)]
 pub enum AccessKeyError<I> {
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::Error<I>>),
+    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::ContextError<I>>),
 
     #[error("unspecified crypto error")]
     CryptoFailure,

--- a/src/codec/crypto/access_key.rs
+++ b/src/codec/crypto/access_key.rs
@@ -1,7 +1,6 @@
 use chacha20poly1305::{AeadInPlace, Key as ChaChaKey, KeyInit, XChaCha20Poly1305};
 use ecdsa::signature::rand_core::CryptoRngCore;
 use rand::Rng;
-use winnow::stream::AsBytes;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::codec::crypto::{
@@ -110,7 +109,7 @@ impl From<[u8; ACCESS_KEY_LENGTH]> for AccessKey {
 #[derive(Debug, thiserror::Error)]
 pub enum AccessKeyError<I> {
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] winnow::Err<winnow::error::Error<I>>),
+    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::Error<I>>),
 
     #[error("unspecified crypto error")]
     CryptoFailure,

--- a/src/codec/crypto/access_key.rs
+++ b/src/codec/crypto/access_key.rs
@@ -1,7 +1,7 @@
 use chacha20poly1305::{AeadInPlace, Key as ChaChaKey, KeyInit, XChaCha20Poly1305};
 use ecdsa::signature::rand_core::CryptoRngCore;
-use nom::AsBytes;
 use rand::Rng;
+use winnow::stream::AsBytes;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::codec::crypto::{
@@ -42,7 +42,7 @@ impl AccessKey {
         let raw_tag = cipher.encrypt_in_place_detached(&nonce, authenticated_data, buffer)?;
 
         let mut tag_bytes = [0u8; AuthenticationTag::size()];
-        tag_bytes.copy_from_slice(raw_tag.as_bytes());
+        tag_bytes.copy_from_slice(raw_tag.as_slice());
         let tag = AuthenticationTag::from(tag_bytes);
 
         Ok((nonce, tag))
@@ -110,7 +110,7 @@ impl From<[u8; ACCESS_KEY_LENGTH]> for AccessKey {
 #[derive(Debug, thiserror::Error)]
 pub enum AccessKeyError<I> {
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] nom::Err<nom::error::Error<I>>),
+    FormatFailure(#[from] winnow::Err<winnow::error::Error<I>>),
 
     #[error("unspecified crypto error")]
     CryptoFailure,

--- a/src/codec/crypto/asym_locked_access_key.rs
+++ b/src/codec/crypto/asym_locked_access_key.rs
@@ -1,10 +1,10 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce, SigningKey, VerifyingKey};
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 pub struct AsymLockedAccessKey {
     pub(crate) dh_exchange_key: VerifyingKey,
@@ -30,7 +30,7 @@ impl AsymLockedAccessKey {
 
         Ok(written_bytes)
     }
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, (dh_exchange_key, nonce, raw_cipher_text, tag)) = (
             VerifyingKey::parse,
             Nonce::parse,

--- a/src/codec/crypto/asym_locked_access_key.rs
+++ b/src/codec/crypto/asym_locked_access_key.rs
@@ -1,7 +1,7 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::streaming::take;
-use winnow::sequence::tuple;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce, SigningKey, VerifyingKey};
 use crate::codec::ParserResult;
@@ -31,14 +31,15 @@ impl AsymLockedAccessKey {
         Ok(written_bytes)
     }
     pub fn parse(input: &[u8]) -> ParserResult<Self> {
-        let (input, (dh_exchange_key, nonce, raw_cipher_text, tag)) = tuple((
+        let (input, (dh_exchange_key, nonce, raw_cipher_text, tag)) = (
             VerifyingKey::parse,
             Nonce::parse,
             // This is NOT being parsed into the target data type yet as its still encrypted. We'll
             // construct it when the contents are valid.
             take(AccessKey::size()),
             AuthenticationTag::parse,
-        ))(input)?;
+        )
+            .parse_next(input)?;
 
         let mut cipher_text = [0u8; AccessKey::size()];
         cipher_text.copy_from_slice(raw_cipher_text);

--- a/src/codec/crypto/asym_locked_access_key.rs
+++ b/src/codec/crypto/asym_locked_access_key.rs
@@ -1,7 +1,7 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
-use nom::sequence::tuple;
+use winnow::bytes::streaming::take;
+use winnow::sequence::tuple;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce, SigningKey, VerifyingKey};
 use crate::codec::ParserResult;

--- a/src/codec/crypto/asym_locked_access_key.rs
+++ b/src/codec/crypto/asym_locked_access_key.rs
@@ -1,7 +1,7 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
-use winnow::Parser;
+use winnow::token::take;
+use winnow::{unpeek, Parser};
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce, SigningKey, VerifyingKey};
 use crate::codec::{ParserResult, Stream};
@@ -32,14 +32,14 @@ impl AsymLockedAccessKey {
     }
     pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, (dh_exchange_key, nonce, raw_cipher_text, tag)) = (
-            VerifyingKey::parse,
-            Nonce::parse,
+            unpeek(VerifyingKey::parse),
+            unpeek(Nonce::parse),
             // This is NOT being parsed into the target data type yet as its still encrypted. We'll
             // construct it when the contents are valid.
             take(AccessKey::size()),
-            AuthenticationTag::parse,
+            unpeek(AuthenticationTag::parse),
         )
-            .parse_next(input)?;
+            .parse_peek(input)?;
 
         let mut cipher_text = [0u8; AccessKey::size()];
         cipher_text.copy_from_slice(raw_cipher_text);

--- a/src/codec/crypto/authentication_tag.rs
+++ b/src/codec/crypto/authentication_tag.rs
@@ -77,6 +77,6 @@ mod tests {
     async fn test_authentication_tag_parsing_stream_too_short() {
         let input = [0u8; TAG_LENGTH - 1];
         let result = AuthenticationTag::parse(&input);
-        assert!(matches!(result, Err(winnow::Err::Incomplete(_))));
+        assert!(matches!(result, Err(winnow::error::ErrMode::Incomplete(_))));
     }
 }

--- a/src/codec/crypto/authentication_tag.rs
+++ b/src/codec/crypto/authentication_tag.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use chacha20poly1305::Tag as ChaChaTag;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -25,7 +25,7 @@ impl AuthenticationTag {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, slice) = take(TAG_LENGTH)(input)?;
+        let (remaining, slice) = take(TAG_LENGTH).parse_next(input)?;
 
         let mut bytes = [0u8; TAG_LENGTH];
         bytes.copy_from_slice(slice);

--- a/src/codec/crypto/authentication_tag.rs
+++ b/src/codec/crypto/authentication_tag.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use chacha20poly1305::Tag as ChaChaTag;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -25,7 +25,7 @@ impl AuthenticationTag {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, slice) = take(TAG_LENGTH).parse_next(input)?;
+        let (remaining, slice) = take(TAG_LENGTH).parse_peek(input)?;
 
         let mut bytes = [0u8; TAG_LENGTH];
         bytes.copy_from_slice(slice);

--- a/src/codec/crypto/authentication_tag.rs
+++ b/src/codec/crypto/authentication_tag.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use chacha20poly1305::Tag as ChaChaTag;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::ParserResult;
 
@@ -77,6 +77,6 @@ mod tests {
     async fn test_authentication_tag_parsing_stream_too_short() {
         let input = [0u8; TAG_LENGTH - 1];
         let result = AuthenticationTag::parse(&input);
-        assert!(matches!(result, Err(nom::Err::Incomplete(_))));
+        assert!(matches!(result, Err(winnow::Err::Incomplete(_))));
     }
 }

--- a/src/codec/crypto/encrypted_buffer.rs
+++ b/src/codec/crypto/encrypted_buffer.rs
@@ -28,7 +28,7 @@ impl EncryptedBuffer {
 
         if let Err(err) = access_key.decrypt_buffer(nonce, authenticated_data, &mut buffer, tag) {
             tracing::error!("failed to decrypt permission buffer: {err}");
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/crypto/encrypted_buffer.rs
+++ b/src/codec/crypto/encrypted_buffer.rs
@@ -4,6 +4,7 @@ use elliptic_curve::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 use winnow::bytes::take;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
 use crate::codec::{ParserResult, Stream};
@@ -21,7 +22,7 @@ impl EncryptedBuffer {
         access_key: &AccessKey,
     ) -> ParserResult<'a, Vec<u8>> {
         let (input, nonce) = Nonce::parse(input)?;
-        let (input, encrypted_slice) = take(payload_size)(input)?;
+        let (input, encrypted_slice) = take(payload_size).parse_next(input)?;
         let (input, tag) = AuthenticationTag::parse(input)?;
 
         let mut buffer = encrypted_slice.to_vec();

--- a/src/codec/crypto/encrypted_buffer.rs
+++ b/src/codec/crypto/encrypted_buffer.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use elliptic_curve::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
@@ -28,8 +28,8 @@ impl EncryptedBuffer {
 
         if let Err(err) = access_key.decrypt_buffer(nonce, authenticated_data, &mut buffer, tag) {
             tracing::error!("failed to decrypt permission buffer: {err}");
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         Ok((input, buffer))

--- a/src/codec/crypto/encrypted_buffer.rs
+++ b/src/codec/crypto/encrypted_buffer.rs
@@ -29,7 +29,7 @@ impl EncryptedBuffer {
         if let Err(err) = access_key.decrypt_buffer(nonce, authenticated_data, &mut buffer, tag) {
             tracing::error!("failed to decrypt permission buffer: {err}");
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         Ok((input, buffer))

--- a/src/codec/crypto/fingerprint.rs
+++ b/src/codec/crypto/fingerprint.rs
@@ -1,5 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
+use winnow::Parser;
 
 use crate::codec::crypto::{KeyId, VerifyingKey};
 use crate::codec::{ParserResult, Stream};
@@ -31,7 +32,7 @@ impl Fingerprint {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, id_bytes) = take(FINGERPRINT_SIZE)(input)?;
+        let (remaining, id_bytes) = take(FINGERPRINT_SIZE).parse_next(input)?;
 
         let mut bytes = [0u8; FINGERPRINT_SIZE];
         bytes.copy_from_slice(id_bytes);

--- a/src/codec/crypto/fingerprint.rs
+++ b/src/codec/crypto/fingerprint.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::crypto::{KeyId, VerifyingKey};
 use crate::codec::ParserResult;

--- a/src/codec/crypto/fingerprint.rs
+++ b/src/codec/crypto/fingerprint.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::token::take;
 use winnow::Parser;
 
 use crate::codec::crypto::{KeyId, VerifyingKey};
@@ -32,7 +32,7 @@ impl Fingerprint {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, id_bytes) = take(FINGERPRINT_SIZE).parse_next(input)?;
+        let (remaining, id_bytes) = take(FINGERPRINT_SIZE).parse_peek(input)?;
 
         let mut bytes = [0u8; FINGERPRINT_SIZE];
         bytes.copy_from_slice(id_bytes);

--- a/src/codec/crypto/fingerprint.rs
+++ b/src/codec/crypto/fingerprint.rs
@@ -1,8 +1,8 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 
 use crate::codec::crypto::{KeyId, VerifyingKey};
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const FINGERPRINT_SIZE: usize = 32;
 
@@ -30,7 +30,7 @@ impl Fingerprint {
         KeyId::from(u16::from_le_bytes(key_id))
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, id_bytes) = take(FINGERPRINT_SIZE)(input)?;
 
         let mut bytes = [0u8; FINGERPRINT_SIZE];

--- a/src/codec/crypto/key_id.rs
+++ b/src/codec/crypto/key_id.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u16;
+use winnow::binary::le_u16;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/crypto/key_id.rs
+++ b/src/codec/crypto/key_id.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u16;
+use winnow::number::streaming::le_u16;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/crypto/key_id.rs
+++ b/src/codec/crypto/key_id.rs
@@ -1,9 +1,9 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u16;
+use winnow::number::le_u16;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub struct KeyId(u16);
@@ -18,7 +18,7 @@ impl KeyId {
         Ok(key_id_bytes.len())
     }
 
-    pub(crate) fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub(crate) fn parse(input: Stream) -> ParserResult<Self> {
         let (input, key_id) = le_u16(input)?;
         Ok((input, Self(key_id)))
     }

--- a/src/codec/crypto/key_id.rs
+++ b/src/codec/crypto/key_id.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u16;
+use winnow::{binary::le_u16, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -19,7 +19,7 @@ impl KeyId {
     }
 
     pub(crate) fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, key_id) = le_u16(input)?;
+        let (input, key_id) = le_u16.parse_peek(input)?;
         Ok((input, Self(key_id)))
     }
 

--- a/src/codec/crypto/nonce.rs
+++ b/src/codec/crypto/nonce.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use chacha20poly1305::XNonce as ChaChaNonce;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use rand::Rng;
 
 use crate::codec::ParserResult;
@@ -74,6 +74,6 @@ mod tests {
     async fn test_nonce_parsing_stream_too_short() {
         let input = [0u8; NONCE_LENGTH - 1];
         let result = Nonce::parse(&input);
-        assert!(matches!(result, Err(nom::Err::Incomplete(_))));
+        assert!(matches!(result, Err(winnow::Err::Incomplete(_))));
     }
 }

--- a/src/codec/crypto/nonce.rs
+++ b/src/codec/crypto/nonce.rs
@@ -74,6 +74,6 @@ mod tests {
     async fn test_nonce_parsing_stream_too_short() {
         let input = [0u8; NONCE_LENGTH - 1];
         let result = Nonce::parse(&input);
-        assert!(matches!(result, Err(winnow::Err::Incomplete(_))));
+        assert!(matches!(result, Err(winnow::error::ErrMode::Incomplete(_))));
     }
 }

--- a/src/codec/crypto/nonce.rs
+++ b/src/codec/crypto/nonce.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use chacha20poly1305::XNonce as ChaChaNonce;
 use futures::{AsyncWrite, AsyncWriteExt};
 use rand::Rng;
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -30,7 +30,7 @@ impl Nonce {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, slice) = take(NONCE_LENGTH)(input)?;
+        let (remaining, slice) = take(NONCE_LENGTH).parse_next(input)?;
 
         let mut bytes = [0u8; NONCE_LENGTH];
         bytes.copy_from_slice(slice);

--- a/src/codec/crypto/nonce.rs
+++ b/src/codec/crypto/nonce.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use chacha20poly1305::XNonce as ChaChaNonce;
 use futures::{AsyncWrite, AsyncWriteExt};
 use rand::Rng;
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -30,7 +30,7 @@ impl Nonce {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, slice) = take(NONCE_LENGTH).parse_next(input)?;
+        let (remaining, slice) = take(NONCE_LENGTH).parse_peek(input)?;
 
         let mut bytes = [0u8; NONCE_LENGTH];
         bytes.copy_from_slice(slice);

--- a/src/codec/crypto/permission_keys.rs
+++ b/src/codec/crypto/permission_keys.rs
@@ -72,7 +72,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, data) = maybe_parse_key(input)?;
@@ -80,7 +80,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, maintenance) = maybe_parse_key(input)?;
@@ -88,7 +88,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let permission_keys = Self {

--- a/src/codec/crypto/permission_keys.rs
+++ b/src/codec/crypto/permission_keys.rs
@@ -72,7 +72,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, data) = maybe_parse_key(input)?;
@@ -80,7 +80,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, maintenance) = maybe_parse_key(input)?;
@@ -88,7 +88,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let permission_keys = Self {

--- a/src/codec/crypto/permission_keys.rs
+++ b/src/codec/crypto/permission_keys.rs
@@ -2,6 +2,7 @@ use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
 use winnow::number::le_u8;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, SigningKey, VerifyingKey};
 use crate::codec::header::KeyAccessSettings;
@@ -167,7 +168,7 @@ fn maybe_parse_key(input: Stream) -> ParserResult<Option<AsymLockedAccessKey>> {
         Ok((input, Some(key)))
     } else {
         // still need to advance the input
-        let (input, _blank) = take(AsymLockedAccessKey::size())(input)?;
+        let (input, _blank) = take(AsymLockedAccessKey::size()).parse_next(input)?;
         Ok((input, None))
     }
 }

--- a/src/codec/crypto/permission_keys.rs
+++ b/src/codec/crypto/permission_keys.rs
@@ -1,7 +1,7 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
+use winnow::binary::le_u8;
 use winnow::bytes::take;
-use winnow::number::le_u8;
 use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, SigningKey, VerifyingKey};

--- a/src/codec/crypto/permission_keys.rs
+++ b/src/codec/crypto/permission_keys.rs
@@ -1,7 +1,7 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
-use nom::number::streaming::le_u8;
+use winnow::bytes::streaming::take;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, SigningKey, VerifyingKey};
 use crate::codec::header::KeyAccessSettings;
@@ -72,7 +72,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, data) = maybe_parse_key(input)?;
@@ -80,7 +80,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let (input, maintenance) = maybe_parse_key(input)?;
@@ -88,7 +88,7 @@ impl PermissionKeys {
             .map(|key| key.unlock(unlock_key))
             .transpose()
             .map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
 
         let permission_keys = Self {

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -31,7 +31,7 @@ impl Signature {
             Ok(signature) => signature,
             Err(_) => {
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-                return Err(winnow::Err::Cut(err));
+                return Err(winnow::error::ErrMode::Cut(err));
             }
         };
 

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -30,7 +30,7 @@ impl Signature {
         let signature = match Signature::from_slice(signature_bytes) {
             Ok(signature) => signature,
             Err(_) => {
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -1,6 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use p384::NistP384;
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -26,12 +26,12 @@ impl Signature {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, signature_bytes) = take(SIGNATURE_SIZE).parse_next(input)?;
+        let (remaining, signature_bytes) = take(SIGNATURE_SIZE).parse_peek(input)?;
         let signature = match Signature::from_slice(signature_bytes) {
             Ok(signature) => signature,
             Err(_) => {
-                let err = winnow::error::ParseError::from_error_kind(
-                    input,
+                let err = winnow::error::ParserError::from_error_kind(
+                    &input,
                     winnow::error::ErrorKind::Verify,
                 );
                 return Err(winnow::error::ErrMode::Cut(err));

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use p384::NistP384;
 
 use crate::codec::ParserResult;
@@ -30,8 +30,8 @@ impl Signature {
         let signature = match Signature::from_slice(signature_bytes) {
             Ok(signature) => signature,
             Err(_) => {
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-                return Err(nom::Err::Failure(err));
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                return Err(winnow::Err::Cut(err));
             }
         };
 

--- a/src/codec/crypto/signature.rs
+++ b/src/codec/crypto/signature.rs
@@ -1,6 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use p384::NistP384;
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -26,7 +26,7 @@ impl Signature {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, signature_bytes) = take(SIGNATURE_SIZE)(input)?;
+        let (remaining, signature_bytes) = take(SIGNATURE_SIZE).parse_next(input)?;
         let signature = match Signature::from_slice(signature_bytes) {
             Ok(signature) => signature,
             Err(_) => {

--- a/src/codec/crypto/sym_locked_access_key.rs
+++ b/src/codec/crypto/sym_locked_access_key.rs
@@ -69,7 +69,7 @@ pub enum SymLockedAccessKeyError<I> {
     CryptoFailure(String),
 
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] winnow::Err<winnow::error::Error<I>>),
+    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::Error<I>>),
 
     #[error("validation failed most likely due to the use of an incorrect key")]
     IncorrectKey,

--- a/src/codec/crypto/sym_locked_access_key.rs
+++ b/src/codec/crypto/sym_locked_access_key.rs
@@ -1,6 +1,6 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
 use crate::codec::ParserResult;
@@ -69,7 +69,7 @@ pub enum SymLockedAccessKeyError<I> {
     CryptoFailure(String),
 
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] nom::Err<nom::error::Error<I>>),
+    FormatFailure(#[from] winnow::Err<winnow::error::Error<I>>),
 
     #[error("validation failed most likely due to the use of an incorrect key")]
     IncorrectKey,

--- a/src/codec/crypto/sym_locked_access_key.rs
+++ b/src/codec/crypto/sym_locked_access_key.rs
@@ -1,6 +1,6 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::token::take;
 use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
@@ -30,7 +30,7 @@ impl SymLockedAccessKey {
     pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, nonce) = Nonce::parse(input)?;
 
-        let (remaining, cipher_text) = take(AccessKey::size()).parse_next(remaining)?;
+        let (remaining, cipher_text) = take(AccessKey::size()).parse_peek(remaining)?;
         let mut fixed_cipher_text = [0u8; AccessKey::size()];
         fixed_cipher_text.copy_from_slice(cipher_text);
 
@@ -70,7 +70,7 @@ pub enum SymLockedAccessKeyError<I> {
     CryptoFailure(String),
 
     #[error("decoding data failed: {0}")]
-    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::Error<I>>),
+    FormatFailure(#[from] winnow::error::ErrMode<winnow::error::ContextError<I>>),
 
     #[error("validation failed most likely due to the use of an incorrect key")]
     IncorrectKey,

--- a/src/codec/crypto/sym_locked_access_key.rs
+++ b/src/codec/crypto/sym_locked_access_key.rs
@@ -1,6 +1,7 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
 use crate::codec::{ParserResult, Stream};
@@ -29,7 +30,7 @@ impl SymLockedAccessKey {
     pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, nonce) = Nonce::parse(input)?;
 
-        let (remaining, cipher_text) = take(AccessKey::size())(remaining)?;
+        let (remaining, cipher_text) = take(AccessKey::size()).parse_next(remaining)?;
         let mut fixed_cipher_text = [0u8; AccessKey::size()];
         fixed_cipher_text.copy_from_slice(cipher_text);
 

--- a/src/codec/crypto/sym_locked_access_key.rs
+++ b/src/codec/crypto/sym_locked_access_key.rs
@@ -1,9 +1,9 @@
 use chacha20poly1305::{AeadInPlace, KeyInit, XChaCha20Poly1305};
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 
 use crate::codec::crypto::{AccessKey, AuthenticationTag, Nonce};
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone)]
 pub struct SymLockedAccessKey {
@@ -26,7 +26,7 @@ impl SymLockedAccessKey {
 
         Ok(written_bytes)
     }
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, nonce) = Nonce::parse(input)?;
 
         let (remaining, cipher_text) = take(AccessKey::size())(remaining)?;

--- a/src/codec/crypto/verifying_key.rs
+++ b/src/codec/crypto/verifying_key.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use ecdsa::signature::rand_core::CryptoRngCore;
 use elliptic_curve::pkcs8::EncodePublicKey;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use p384::ecdh::EphemeralSecret;
 use p384::{NistP384, PublicKey};
 
@@ -94,8 +94,8 @@ impl VerifyingKey {
             Ok(key) => key,
             Err(err) => {
                 tracing::error!("failed to decode ECDSA key: {err}");
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-                return Err(nom::Err::Failure(err));
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                return Err(winnow::Err::Cut(err));
             }
         };
 

--- a/src/codec/crypto/verifying_key.rs
+++ b/src/codec/crypto/verifying_key.rs
@@ -94,7 +94,7 @@ impl VerifyingKey {
             Ok(key) => key,
             Err(err) => {
                 tracing::error!("failed to decode ECDSA key: {err}");
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };

--- a/src/codec/crypto/verifying_key.rs
+++ b/src/codec/crypto/verifying_key.rs
@@ -3,13 +3,13 @@ use std::ops::Deref;
 use ecdsa::signature::rand_core::CryptoRngCore;
 use elliptic_curve::pkcs8::EncodePublicKey;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
 use p384::ecdh::EphemeralSecret;
 use p384::{NistP384, PublicKey};
+use winnow::bytes::take;
 
 use crate::codec::crypto::{AccessKey, Fingerprint, KeyId};
-use crate::codec::ActorId;
 use crate::codec::ParserResult;
+use crate::codec::{ActorId, Stream};
 
 const KEY_SIZE: usize = 49;
 
@@ -84,7 +84,7 @@ impl VerifyingKey {
         self.fingerprint().key_id()
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, slice) = take(KEY_SIZE)(input)?;
 
         let mut bytes = [0u8; KEY_SIZE];
@@ -94,7 +94,10 @@ impl VerifyingKey {
             Ok(key) => key,
             Err(err) => {
                 tracing::error!("failed to decode ECDSA key: {err}");
-                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(
+                    input,
+                    winnow::error::ErrorKind::Verify,
+                );
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };

--- a/src/codec/crypto/verifying_key.rs
+++ b/src/codec/crypto/verifying_key.rs
@@ -6,6 +6,7 @@ use futures::{AsyncWrite, AsyncWriteExt};
 use p384::ecdh::EphemeralSecret;
 use p384::{NistP384, PublicKey};
 use winnow::bytes::take;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, Fingerprint, KeyId};
 use crate::codec::ParserResult;
@@ -85,7 +86,7 @@ impl VerifyingKey {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, slice) = take(KEY_SIZE)(input)?;
+        let (remaining, slice) = take(KEY_SIZE).parse_next(input)?;
 
         let mut bytes = [0u8; KEY_SIZE];
         bytes.copy_from_slice(slice);

--- a/src/codec/crypto/verifying_key.rs
+++ b/src/codec/crypto/verifying_key.rs
@@ -95,7 +95,7 @@ impl VerifyingKey {
             Err(err) => {
                 tracing::error!("failed to decode ECDSA key: {err}");
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-                return Err(winnow::Err::Cut(err));
+                return Err(winnow::error::ErrMode::Cut(err));
             }
         };
 

--- a/src/codec/filesystem/block_kind.rs
+++ b/src/codec/filesystem/block_kind.rs
@@ -48,7 +48,7 @@ impl BlockKind {
             }
             _ => {
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-                Err(winnow::Err::Cut(err))
+                Err(winnow::error::ErrMode::Cut(err))
             }
         }
     }

--- a/src/codec/filesystem/block_kind.rs
+++ b/src/codec/filesystem/block_kind.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::{le_u64, le_u8};
+use winnow::number::streaming::{le_u64, le_u8};
 
 use crate::codec::ParserResult;
 
@@ -47,8 +47,8 @@ impl BlockKind {
                 Ok((input, Self::IndirectReference { total_size }))
             }
             _ => {
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-                Err(nom::Err::Failure(err))
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                Err(winnow::Err::Cut(err))
             }
         }
     }

--- a/src/codec/filesystem/block_kind.rs
+++ b/src/codec/filesystem/block_kind.rs
@@ -47,7 +47,7 @@ impl BlockKind {
                 Ok((input, Self::IndirectReference { total_size }))
             }
             _ => {
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
                 Err(winnow::error::ErrMode::Cut(err))
             }
         }

--- a/src/codec/filesystem/block_kind.rs
+++ b/src/codec/filesystem/block_kind.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::{le_u64, le_u8};
+use winnow::number::{le_u64, le_u8};
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Debug)]
 pub enum BlockKind {
@@ -37,7 +37,7 @@ impl BlockKind {
         Self::IndirectReference { total_size }
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, kind) = le_u8(input)?;
 
         match kind {
@@ -47,7 +47,10 @@ impl BlockKind {
                 Ok((input, Self::IndirectReference { total_size }))
             }
             _ => {
-                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(
+                    input,
+                    winnow::error::ErrorKind::Verify,
+                );
                 Err(winnow::error::ErrMode::Cut(err))
             }
         }

--- a/src/codec/filesystem/block_kind.rs
+++ b/src/codec/filesystem/block_kind.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::{le_u64, le_u8};
+use winnow::binary::{le_u64, le_u8};
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u8;
+use winnow::number::le_u8;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const DIRECTORY_PERMISSIONS_RESERVED_MASK: u8 = 0b1111_1100;
 
@@ -42,11 +42,12 @@ impl DirectoryPermissions {
         self.immutable
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & DIRECTORY_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err =
+                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u8;
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -43,11 +43,13 @@ impl DirectoryPermissions {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, byte) = le_u8(input)?;
+        let (input, byte) = le_u8.parse_peek(input)?;
 
         if cfg!(feature = "strict") && byte & DIRECTORY_PERMISSIONS_RESERVED_MASK != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 
@@ -46,8 +46,8 @@ impl DirectoryPermissions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & DIRECTORY_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let owner_write_only = byte & DIRECTORY_PERMISSIONS_OWNER_WRITE_ONLY != 0;

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -47,7 +47,7 @@ impl DirectoryPermissions {
 
         if cfg!(feature = "strict") && byte & DIRECTORY_PERMISSIONS_RESERVED_MASK != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let owner_write_only = byte & DIRECTORY_PERMISSIONS_OWNER_WRITE_ONLY != 0;

--- a/src/codec/filesystem/directory_permissions.rs
+++ b/src/codec/filesystem/directory_permissions.rs
@@ -46,7 +46,7 @@ impl DirectoryPermissions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & DIRECTORY_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 
@@ -60,8 +60,8 @@ impl FilePermissions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & FILE_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let owner_write_only = byte & FILE_PERMISSIONS_OWNER_WRITE_ONLY != 0;

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u8;
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -57,11 +57,13 @@ impl FilePermissions {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, byte) = le_u8(input)?;
+        let (input, byte) = le_u8.parse_peek(input)?;
 
         if cfg!(feature = "strict") && byte & FILE_PERMISSIONS_RESERVED_MASK != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u8;
+use winnow::number::le_u8;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const FILE_PERMISSIONS_RESERVED_MASK: u8 = 0b1111_1000;
 
@@ -56,11 +56,12 @@ impl FilePermissions {
         self.immutable
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & FILE_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err =
+                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -60,7 +60,7 @@ impl FilePermissions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & FILE_PERMISSIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/filesystem/file_permissions.rs
+++ b/src/codec/filesystem/file_permissions.rs
@@ -61,7 +61,7 @@ impl FilePermissions {
 
         if cfg!(feature = "strict") && byte & FILE_PERMISSIONS_RESERVED_MASK != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let owner_write_only = byte & FILE_PERMISSIONS_OWNER_WRITE_ONLY != 0;

--- a/src/codec/filesystem/node_kind.rs
+++ b/src/codec/filesystem/node_kind.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -33,7 +33,7 @@ impl NodeKind {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, node_type) = take(1u8).parse_next(input)?;
+        let (input, node_type) = take(1u8).parse_peek(input)?;
         let node_type = node_type[0];
 
         let parsed_type = match node_type {

--- a/src/codec/filesystem/node_kind.rs
+++ b/src/codec/filesystem/node_kind.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/filesystem/node_kind.rs
+++ b/src/codec/filesystem/node_kind.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum NodeKind {
@@ -32,7 +32,7 @@ impl NodeKind {
         Ok(1)
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, node_type) = take(1u8)(input)?;
         let node_type = node_type[0];
 
@@ -63,7 +63,7 @@ mod tests {
         let node_type = NodeKind::File;
         let source_bytes = [0x00];
 
-        let (remaining, parsed) = NodeKind::parse(&source_bytes).unwrap();
+        let (remaining, parsed) = NodeKind::parse(Stream::new(&source_bytes)).unwrap();
 
         assert!(remaining.is_empty());
         assert_eq!(node_type, parsed);

--- a/src/codec/filesystem/node_kind.rs
+++ b/src/codec/filesystem/node_kind.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -33,7 +33,7 @@ impl NodeKind {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, node_type) = take(1u8)(input)?;
+        let (input, node_type) = take(1u8).parse_next(input)?;
         let node_type = node_type[0];
 
         let parsed_type = match node_type {

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u8;
+use winnow::number::le_u8;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const CONTENT_OPTIONS_RESERVED_MASK: u8 = 0b1111_1000;
 
@@ -66,11 +66,12 @@ impl ContentOptions {
         Ok(1)
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & CONTENT_OPTIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err =
+                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 
@@ -70,8 +70,8 @@ impl ContentOptions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & CONTENT_OPTIONS_RESERVED_MASK != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let filesystem = byte & CONTENT_OPTIONS_FILESYSTEM_BIT != 0;

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u8;
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -67,11 +67,13 @@ impl ContentOptions {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, byte) = le_u8(input)?;
+        let (input, byte) = le_u8.parse_peek(input)?;
 
         if cfg!(feature = "strict") && byte & CONTENT_OPTIONS_RESERVED_MASK != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -71,7 +71,7 @@ impl ContentOptions {
 
         if cfg!(feature = "strict") && byte & CONTENT_OPTIONS_RESERVED_MASK != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let filesystem = byte & CONTENT_OPTIONS_FILESYSTEM_BIT != 0;

--- a/src/codec/header/content_options.rs
+++ b/src/codec/header/content_options.rs
@@ -70,7 +70,7 @@ impl ContentOptions {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & CONTENT_OPTIONS_RESERVED_MASK != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -2,7 +2,7 @@ use elliptic_curve::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
 use rand::Rng;
 use winnow::bytes::{tag, take};
-use winnow::number::{le_u64, le_u8};
+use winnow::binary::{le_u64, le_u8};
 use winnow::stream::Offset;
 use winnow::Parser;
 

--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -228,7 +228,6 @@ impl DataBlock {
 
         let mut contents = Vec::with_capacity(chunk_count);
         for _ in 0..chunk_count {
-            //let (input, chunk_data) = take(base_chunk_size)(input)?;
             let chunk_start = input;
 
             let (input, nonce) = Nonce::parse(input)?;

--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -4,6 +4,7 @@ use rand::Rng;
 use winnow::bytes::{tag, take};
 use winnow::number::{le_u64, le_u8};
 use winnow::stream::Offset;
+use winnow::Parser;
 
 use crate::codec::crypto::{
     AccessKey, AuthenticationTag, Nonce, Signature, SigningKey, VerifyingKey,
@@ -228,7 +229,7 @@ impl DataBlock {
             let chunk_start = input;
 
             let (input, nonce) = Nonce::parse(input)?;
-            let (input, data) = take(encrypted_chunk_size)(input)?;
+            let (input, data) = take(encrypted_chunk_size).parse_next(input)?;
             let (input, tag) = AuthenticationTag::parse(input)?;
 
             debug_assert!(
@@ -416,7 +417,7 @@ impl DataOptions {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, version_byte) = take(1u8)(input)?;
+        let (input, version_byte) = take(1u8).parse_next(input)?;
         let option_byte = version_byte[0];
 
         let ecc_present = (option_byte & ECC_PRESENT_BIT) == ECC_PRESENT_BIT;
@@ -438,5 +439,5 @@ impl DataOptions {
 }
 
 fn banyan_data_magic_tag(input: Stream) -> ParserResult<&[u8]> {
-    tag(BANYAN_DATA_MAGIC)(input)
+    tag(BANYAN_DATA_MAGIC).parse_next(input)
 }

--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -197,7 +197,7 @@ impl DataBlock {
         let (input, version) = le_u8(input)?;
 
         if version != 0x01 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 
@@ -233,7 +233,7 @@ impl DataBlock {
             let mut plaintext_data = data.to_vec();
             if let Err(err) = access_key.decrypt_buffer(nonce, &[], &mut plaintext_data, tag) {
                 tracing::error!("failed to decrypt chunk: {err}");
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
                 return Err(winnow::error::ErrMode::Cut(err));
             }
 
@@ -244,7 +244,7 @@ impl DataBlock {
                         tracing::error!("failed to read inner length: {err:?}");
 
                         let empty_static: &'static [u8] = &[];
-                        return Err(winnow::error::ErrMode::Cut(winnow::error::make_error(
+                        return Err(winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
                             empty_static,
                             winnow::error::ErrorKind::Verify,
                         )));

--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -198,7 +198,7 @@ impl DataBlock {
 
         if version != 0x01 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let (input, cid) = Cid::parse(input)?;
@@ -234,7 +234,7 @@ impl DataBlock {
             if let Err(err) = access_key.decrypt_buffer(nonce, &[], &mut plaintext_data, tag) {
                 tracing::error!("failed to decrypt chunk: {err}");
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-                return Err(winnow::Err::Cut(err));
+                return Err(winnow::error::ErrMode::Cut(err));
             }
 
             let data_length =
@@ -244,7 +244,7 @@ impl DataBlock {
                         tracing::error!("failed to read inner length: {err:?}");
 
                         let empty_static: &'static [u8] = &[];
-                        return Err(winnow::Err::Cut(winnow::error::make_error(
+                        return Err(winnow::error::ErrMode::Cut(winnow::error::make_error(
                             empty_static,
                             winnow::error::ErrorKind::Verify,
                         )));

--- a/src/codec/header/format_header.rs
+++ b/src/codec/header/format_header.rs
@@ -1,7 +1,7 @@
 use futures::AsyncWrite;
 use winnow::Parser;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 use crate::codec::header::{IdentityHeader, PublicSettings};
 use crate::codec::FilesystemId;
@@ -29,7 +29,7 @@ impl FormatHeader {
         Ok(written_bytes)
     }
 
-    pub fn parse_with_magic(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse_with_magic(input: Stream) -> ParserResult<Self> {
         let mut header_parser = (
             IdentityHeader::parse_with_magic,
             FilesystemId::parse,
@@ -74,7 +74,7 @@ mod tests {
         // A public non-ECC header
         source.extend(&[0x00]);
 
-        let (remaining, parsed) = FormatHeader::parse_with_magic(&source).unwrap();
+        let (remaining, parsed) = FormatHeader::parse_with_magic(Stream::new(&source)).unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
             parsed,

--- a/src/codec/header/format_header.rs
+++ b/src/codec/header/format_header.rs
@@ -1,5 +1,5 @@
 use futures::AsyncWrite;
-use nom::sequence::tuple;
+use winnow::sequence::tuple;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/header/format_header.rs
+++ b/src/codec/header/format_header.rs
@@ -1,5 +1,5 @@
 use futures::AsyncWrite;
-use winnow::sequence::tuple;
+use winnow::Parser;
 
 use crate::codec::ParserResult;
 
@@ -30,13 +30,13 @@ impl FormatHeader {
     }
 
     pub fn parse_with_magic(input: &[u8]) -> ParserResult<Self> {
-        let mut header_parser = tuple((
+        let mut header_parser = (
             IdentityHeader::parse_with_magic,
             FilesystemId::parse,
             PublicSettings::parse,
-        ));
+        );
 
-        let (input, (_, filesystem_id, settings)) = header_parser(input)?;
+        let (input, (_, filesystem_id, settings)) = header_parser.parse_next(input)?;
 
         let header = FormatHeader {
             ecc_present: settings.ecc_present(),

--- a/src/codec/header/format_header.rs
+++ b/src/codec/header/format_header.rs
@@ -1,5 +1,4 @@
 use futures::AsyncWrite;
-use winnow::Parser;
 
 use crate::codec::{ParserResult, Stream};
 
@@ -30,13 +29,9 @@ impl FormatHeader {
     }
 
     pub fn parse_with_magic(input: Stream) -> ParserResult<Self> {
-        let mut header_parser = (
-            IdentityHeader::parse_with_magic,
-            FilesystemId::parse,
-            PublicSettings::parse,
-        );
-
-        let (input, (_, filesystem_id, settings)) = header_parser.parse_next(input)?;
+        let (input, _) = IdentityHeader::parse_with_magic(input)?;
+        let (input, filesystem_id) = FilesystemId::parse(input)?;
+        let (input, settings) = PublicSettings::parse(input)?;
 
         let header = FormatHeader {
             ecc_present: settings.ecc_present(),

--- a/src/codec/header/identity_header.rs
+++ b/src/codec/header/identity_header.rs
@@ -24,7 +24,7 @@ impl IdentityHeader {
 
         // Only version one is valid
         if version != 0x01 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 
@@ -44,7 +44,7 @@ fn version_field(input: &[u8]) -> ParserResult<u8> {
     // library to enable a stricter parsing mode.
     let reserved = (version_byte & 0x80) >> 7;
     if cfg!(feature = "strict") && reserved != 0 {
-        let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+        let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
         return Err(winnow::error::ErrMode::Cut(err));
     }
 

--- a/src/codec/header/identity_header.rs
+++ b/src/codec/header/identity_header.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::{tag, take};
+use winnow::bytes::streaming::{tag, take};
 
 use crate::codec::header::BANYAN_FS_MAGIC;
 use crate::codec::ParserResult;
@@ -24,8 +24,8 @@ impl IdentityHeader {
 
         // Only version one is valid
         if version != 0x01 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         Ok((input, Self))
@@ -44,8 +44,8 @@ fn version_field(input: &[u8]) -> ParserResult<u8> {
     // library to enable a stricter parsing mode.
     let reserved = (version_byte & 0x80) >> 7;
     if cfg!(feature = "strict") && reserved != 0 {
-        let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-        return Err(nom::Err::Failure(err));
+        let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+        return Err(winnow::Err::Cut(err));
     }
 
     let version = version_byte & 0x7f;

--- a/src/codec/header/identity_header.rs
+++ b/src/codec/header/identity_header.rs
@@ -1,5 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::{tag, take};
+use winnow::Parser;
 
 use crate::codec::header::BANYAN_FS_MAGIC;
 use crate::codec::{ParserResult, Stream};
@@ -34,11 +35,11 @@ impl IdentityHeader {
 }
 
 fn banyanfs_magic_tag(input: Stream) -> ParserResult<&[u8]> {
-    tag(BANYAN_FS_MAGIC)(input)
+    tag(BANYAN_FS_MAGIC).parse_next(input)
 }
 
 fn version_field(input: Stream) -> ParserResult<u8> {
-    let (input, version_byte) = take(1u8)(input)?;
+    let (input, version_byte) = take(1u8).parse_next(input)?;
     let version_byte = version_byte[0];
 
     // The specification indicates decoders SHOULD ignore this bit. We allow the consumers of the

--- a/src/codec/header/identity_header.rs
+++ b/src/codec/header/identity_header.rs
@@ -25,7 +25,7 @@ impl IdentityHeader {
         // Only version one is valid
         if version != 0x01 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         Ok((input, Self))
@@ -45,7 +45,7 @@ fn version_field(input: &[u8]) -> ParserResult<u8> {
     let reserved = (version_byte & 0x80) >> 7;
     if cfg!(feature = "strict") && reserved != 0 {
         let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-        return Err(winnow::Err::Cut(err));
+        return Err(winnow::error::ErrMode::Cut(err));
     }
 
     let version = version_byte & 0x7f;

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -223,7 +223,7 @@ impl KeyAccessSettings {
 
         if cfg!(feature = "strict") && byte & PRIVATE_RESERVED_MASK != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let protected = byte & PROTECTED_BIT != 0;
@@ -252,7 +252,7 @@ impl KeyAccessSettings {
 
         if cfg!(feature = "strict") && byte & PUBLIC_RESERVED_MASK != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let protected = byte & PROTECTED_BIT != 0;

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 
@@ -222,8 +222,8 @@ impl KeyAccessSettings {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PRIVATE_RESERVED_MASK != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let protected = byte & PROTECTED_BIT != 0;
@@ -251,8 +251,8 @@ impl KeyAccessSettings {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PUBLIC_RESERVED_MASK != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let protected = byte & PROTECTED_BIT != 0;

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u8;
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -219,11 +219,13 @@ impl KeyAccessSettings {
     }
 
     pub fn parse_private(input: Stream) -> ParserResult<Self> {
-        let (input, byte) = le_u8(input)?;
+        let (input, byte) = le_u8.parse_peek(input)?;
 
         if cfg!(feature = "strict") && byte & PRIVATE_RESERVED_MASK != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 
@@ -249,11 +251,13 @@ impl KeyAccessSettings {
     }
 
     pub fn parse_public(input: Stream) -> ParserResult<Self> {
-        let (input, byte) = le_u8(input)?;
+        let (input, byte) = le_u8.parse_peek(input)?;
 
         if cfg!(feature = "strict") && byte & PUBLIC_RESERVED_MASK != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u8;
+use winnow::number::le_u8;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const PROTECTED_BIT: u8 = 0b1000_0000;
 
@@ -218,11 +218,12 @@ impl KeyAccessSettings {
         }
     }
 
-    pub fn parse_private(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse_private(input: Stream) -> ParserResult<Self> {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PRIVATE_RESERVED_MASK != 0 {
-            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err =
+                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 
@@ -247,11 +248,12 @@ impl KeyAccessSettings {
         Ok((input, settings))
     }
 
-    pub fn parse_public(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse_public(input: Stream) -> ParserResult<Self> {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PUBLIC_RESERVED_MASK != 0 {
-            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err =
+                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/key_access_settings.rs
+++ b/src/codec/header/key_access_settings.rs
@@ -222,7 +222,7 @@ impl KeyAccessSettings {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PRIVATE_RESERVED_MASK != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 
@@ -251,7 +251,7 @@ impl KeyAccessSettings {
         let (input, byte) = le_u8(input)?;
 
         if cfg!(feature = "strict") && byte & PUBLIC_RESERVED_MASK != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/key_count.rs
+++ b/src/codec/header/key_count.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/header/key_count.rs
+++ b/src/codec/header/key_count.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -17,7 +17,7 @@ impl KeyCount {
         Ok(1)
     }
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, count) = take(1u8)(input)?;
+        let (input, count) = take(1u8).parse_next(input)?;
         Ok((input, Self(count[0])))
     }
 

--- a/src/codec/header/key_count.rs
+++ b/src/codec/header/key_count.rs
@@ -1,9 +1,9 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KeyCount(u8);
@@ -16,7 +16,7 @@ impl KeyCount {
         writer.write_all(&[self.0]).await?;
         Ok(1)
     }
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, count) = take(1u8)(input)?;
         Ok((input, Self(count[0])))
     }

--- a/src/codec/header/key_count.rs
+++ b/src/codec/header/key_count.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -17,7 +17,7 @@ impl KeyCount {
         Ok(1)
     }
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, count) = take(1u8).parse_next(input)?;
+        let (input, count) = take(1u8).parse_peek(input)?;
         Ok((input, Self(count[0])))
     }
 

--- a/src/codec/header/public_settings.rs
+++ b/src/codec/header/public_settings.rs
@@ -52,7 +52,7 @@ impl PublicSettings {
 
         if cfg!(feature = "strict") && (settings_byte & RESERVED_BITS) != 0 {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         let ecc_present = (settings_byte & ECC_PRESENT_BIT) == ECC_PRESENT_BIT;

--- a/src/codec/header/public_settings.rs
+++ b/src/codec/header/public_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::ParserResult;
 
@@ -51,8 +51,8 @@ impl PublicSettings {
         let settings_byte = settings_byte[0];
 
         if cfg!(feature = "strict") && (settings_byte & RESERVED_BITS) != 0 {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         let ecc_present = (settings_byte & ECC_PRESENT_BIT) == ECC_PRESENT_BIT;

--- a/src/codec/header/public_settings.rs
+++ b/src/codec/header/public_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -47,7 +47,7 @@ impl PublicSettings {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, settings_byte) = take(1u8)(input)?;
+        let (input, settings_byte) = take(1u8).parse_next(input)?;
         let settings_byte = settings_byte[0];
 
         if cfg!(feature = "strict") && (settings_byte & RESERVED_BITS) != 0 {

--- a/src/codec/header/public_settings.rs
+++ b/src/codec/header/public_settings.rs
@@ -51,7 +51,7 @@ impl PublicSettings {
         let settings_byte = settings_byte[0];
 
         if cfg!(feature = "strict") && (settings_byte & RESERVED_BITS) != 0 {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/header/public_settings.rs
+++ b/src/codec/header/public_settings.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -47,12 +47,14 @@ impl PublicSettings {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, settings_byte) = take(1u8).parse_next(input)?;
+        let (input, settings_byte) = take(1u8).parse_peek(input)?;
         let settings_byte = settings_byte[0];
 
         if cfg!(feature = "strict") && (settings_byte & RESERVED_BITS) != 0 {
-            let err =
-                winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParserError::from_error_kind(
+                &input,
+                winnow::error::ErrorKind::Verify,
+            );
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/meta/actor_id.rs
+++ b/src/codec/meta/actor_id.rs
@@ -1,7 +1,7 @@
 use futures::AsyncWrite;
 
 use crate::codec::crypto::{Fingerprint, KeyId};
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ActorId(Fingerprint);
@@ -18,7 +18,7 @@ impl ActorId {
         self.0.key_id()
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, fingerprint) = Fingerprint::parse(input)?;
         Ok((remaining, ActorId(fingerprint)))
     }

--- a/src/codec/meta/actor_settings.rs
+++ b/src/codec/meta/actor_settings.rs
@@ -1,6 +1,6 @@
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
-use nom::number::streaming::le_u8;
+use winnow::bytes::streaming::take;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::crypto::VerifyingKey;
 use crate::codec::header::KeyAccessSettings;

--- a/src/codec/meta/actor_settings.rs
+++ b/src/codec/meta/actor_settings.rs
@@ -1,6 +1,6 @@
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 use winnow::Parser;
 
 use crate::codec::crypto::VerifyingKey;

--- a/src/codec/meta/actor_settings.rs
+++ b/src/codec/meta/actor_settings.rs
@@ -1,11 +1,11 @@
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
-use winnow::number::streaming::le_u8;
+use winnow::bytes::take;
+use winnow::number::le_u8;
 
 use crate::codec::crypto::VerifyingKey;
 use crate::codec::header::KeyAccessSettings;
 use crate::codec::meta::VectorClock;
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const SOFTWARE_AGENT_BYTE_STR_SIZE: usize = 63;
 
@@ -71,7 +71,7 @@ impl ActorSettings {
         }
     }
 
-    pub fn parse_private(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse_private(input: Stream) -> ParserResult<Self> {
         let (input, verifying_key) = VerifyingKey::parse(input)?;
         let (input, vector_clock) = VectorClock::parse(input)?;
         let (input, access_settings) = KeyAccessSettings::parse_private(input)?;

--- a/src/codec/meta/actor_settings.rs
+++ b/src/codec/meta/actor_settings.rs
@@ -1,6 +1,7 @@
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
 use winnow::number::le_u8;
+use winnow::Parser;
 
 use crate::codec::crypto::VerifyingKey;
 use crate::codec::header::KeyAccessSettings;
@@ -77,7 +78,7 @@ impl ActorSettings {
         let (input, access_settings) = KeyAccessSettings::parse_private(input)?;
 
         let (input, agent_len) = le_u8(input)?;
-        let (input, agent_fixed) = take(SOFTWARE_AGENT_BYTE_STR_SIZE)(input)?;
+        let (input, agent_fixed) = take(SOFTWARE_AGENT_BYTE_STR_SIZE).parse_next(input)?;
         let agent = agent_fixed[..agent_len as usize].to_vec();
 
         let actor_settings = Self {

--- a/src/codec/meta/actor_settings.rs
+++ b/src/codec/meta/actor_settings.rs
@@ -1,6 +1,6 @@
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
 use winnow::binary::le_u8;
+use winnow::token::take;
 use winnow::Parser;
 
 use crate::codec::crypto::VerifyingKey;
@@ -77,8 +77,8 @@ impl ActorSettings {
         let (input, vector_clock) = VectorClock::parse(input)?;
         let (input, access_settings) = KeyAccessSettings::parse_private(input)?;
 
-        let (input, agent_len) = le_u8(input)?;
-        let (input, agent_fixed) = take(SOFTWARE_AGENT_BYTE_STR_SIZE).parse_next(input)?;
+        let (input, agent_len) = le_u8.parse_peek(input)?;
+        let (input, agent_fixed) = take(SOFTWARE_AGENT_BYTE_STR_SIZE).parse_peek(input)?;
         let agent = agent_fixed[..agent_len as usize].to_vec();
 
         let actor_settings = Self {

--- a/src/codec/meta/block_size.rs
+++ b/src/codec/meta/block_size.rs
@@ -1,4 +1,4 @@
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 use futures::{AsyncWrite, AsyncWriteExt};

--- a/src/codec/meta/block_size.rs
+++ b/src/codec/meta/block_size.rs
@@ -1,4 +1,4 @@
-use winnow::binary::le_u8;
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 use futures::{AsyncWrite, AsyncWriteExt};
@@ -47,8 +47,8 @@ impl BlockSize {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, total_space) = le_u8(input)?;
-        let (input, chunk_size) = le_u8(input)?;
+        let (input, total_space) = le_u8.parse_peek(input)?;
+        let (input, chunk_size) = le_u8.parse_peek(input)?;
 
         let block_size = Self {
             total_space,

--- a/src/codec/meta/block_size.rs
+++ b/src/codec/meta/block_size.rs
@@ -1,6 +1,6 @@
-use winnow::number::streaming::le_u8;
+use winnow::number::le_u8;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 use futures::{AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug, Clone, Copy)]
@@ -46,7 +46,7 @@ impl BlockSize {
         })
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, total_space) = le_u8(input)?;
         let (input, chunk_size) = le_u8(input)?;
 

--- a/src/codec/meta/block_size.rs
+++ b/src/codec/meta/block_size.rs
@@ -1,4 +1,4 @@
-use winnow::number::le_u8;
+use winnow::binary::le_u8;
 
 use crate::codec::{ParserResult, Stream};
 use futures::{AsyncWrite, AsyncWriteExt};

--- a/src/codec/meta/cid.rs
+++ b/src/codec/meta/cid.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -42,7 +42,7 @@ impl Cid {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, cid_bytes) = take(CID_LENGTH).parse_next(input)?;
+        let (remaining, cid_bytes) = take(CID_LENGTH).parse_peek(input)?;
 
         let mut bytes = [0u8; CID_LENGTH];
         bytes.copy_from_slice(cid_bytes);

--- a/src/codec/meta/cid.rs
+++ b/src/codec/meta/cid.rs
@@ -1,7 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
+use winnow::bytes::take;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const CID_LENGTH: usize = 32;
 
@@ -41,7 +41,7 @@ impl Cid {
         Ok(self.0.len())
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, cid_bytes) = take(CID_LENGTH)(input)?;
 
         let mut bytes = [0u8; CID_LENGTH];

--- a/src/codec/meta/cid.rs
+++ b/src/codec/meta/cid.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -42,7 +42,7 @@ impl Cid {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, cid_bytes) = take(CID_LENGTH)(input)?;
+        let (remaining, cid_bytes) = take(CID_LENGTH).parse_next(input)?;
 
         let mut bytes = [0u8; CID_LENGTH];
         bytes.copy_from_slice(cid_bytes);

--- a/src/codec/meta/cid.rs
+++ b/src/codec/meta/cid.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/meta/filesystem_id.rs
+++ b/src/codec/meta/filesystem_id.rs
@@ -34,7 +34,7 @@ impl FilesystemId {
         if cfg!(feature = "strict")
             && (id_bytes.iter().all(|&b| b == 0x00) || id_bytes.iter().all(|&b| b == 0xff))
         {
-            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
             return Err(winnow::error::ErrMode::Cut(err));
         }
 

--- a/src/codec/meta/filesystem_id.rs
+++ b/src/codec/meta/filesystem_id.rs
@@ -35,7 +35,7 @@ impl FilesystemId {
             && (id_bytes.iter().all(|&b| b == 0x00) || id_bytes.iter().all(|&b| b == 0xff))
         {
             let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-            return Err(winnow::Err::Cut(err));
+            return Err(winnow::error::ErrMode::Cut(err));
         }
 
         // todo(sstelfox): parse into an actually UUID, validate the version, probably store the

--- a/src/codec/meta/filesystem_id.rs
+++ b/src/codec/meta/filesystem_id.rs
@@ -1,6 +1,6 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use uuid::{NoContext, Timestamp, Uuid};
 
 use crate::codec::ParserResult;
@@ -34,8 +34,8 @@ impl FilesystemId {
         if cfg!(feature = "strict")
             && (id_bytes.iter().all(|&b| b == 0x00) || id_bytes.iter().all(|&b| b == 0xff))
         {
-            let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-            return Err(nom::Err::Failure(err));
+            let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+            return Err(winnow::Err::Cut(err));
         }
 
         // todo(sstelfox): parse into an actually UUID, validate the version, probably store the

--- a/src/codec/meta/filesystem_id.rs
+++ b/src/codec/meta/filesystem_id.rs
@@ -1,7 +1,7 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::{AsyncWrite, AsyncWriteExt};
 use uuid::{NoContext, Timestamp, Uuid};
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -27,7 +27,7 @@ impl FilesystemId {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, id_bytes) = take(ID_LENGTH)(input)?;
+        let (remaining, id_bytes) = take(ID_LENGTH).parse_next(input)?;
 
         // All zeros and all ones are disallowed, this isn't actually harmful though so we'll only
         // perform this check in strict mode.

--- a/src/codec/meta/journal_checkpoint.rs
+++ b/src/codec/meta/journal_checkpoint.rs
@@ -1,7 +1,7 @@
 use futures::io::AsyncWrite;
 
 use crate::codec::meta::{Cid, VectorClock};
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Debug)]
 pub struct JournalCheckpoint {
@@ -29,7 +29,7 @@ impl JournalCheckpoint {
         }
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, merkle_root_cid) = Cid::parse(input)?;
         let (input, vector) = VectorClock::parse(input)?;
 

--- a/src/codec/meta/meta_key.rs
+++ b/src/codec/meta/meta_key.rs
@@ -8,7 +8,7 @@ use winnow::multi::count;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, KeyId, SigningKey};
 use crate::codec::header::KeyCount;
-use crate::codec::{ActorSettings, ParserResult};
+use crate::codec::{ActorSettings, ParserResult, Stream};
 
 pub struct MetaKey(AccessKey);
 
@@ -46,7 +46,7 @@ impl MetaKey {
     }
 
     pub fn parse_escrow<'a>(
-        input: &'a [u8],
+        input: Stream<'a>,
         key_count: u8,
         signing_key: &SigningKey,
     ) -> ParserResult<'a, Option<Self>> {

--- a/src/codec/meta/meta_key.rs
+++ b/src/codec/meta/meta_key.rs
@@ -5,7 +5,6 @@ use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::AsyncWrite;
 use winnow::error::Needed;
 use winnow::multi::count;
-use winnow::sequence::tuple;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, KeyId, SigningKey};
 use crate::codec::header::KeyCount;
@@ -52,7 +51,7 @@ impl MetaKey {
         signing_key: &SigningKey,
     ) -> ParserResult<'a, Option<Self>> {
         let mut asym_parser = count(
-            tuple((KeyId::parse, AsymLockedAccessKey::parse)),
+            (KeyId::parse, AsymLockedAccessKey::parse),
             key_count as usize,
         );
 

--- a/src/codec/meta/meta_key.rs
+++ b/src/codec/meta/meta_key.rs
@@ -58,11 +58,11 @@ impl MetaKey {
 
         let (input, locked_keys): (_, Vec<_>) = match asym_parser(input) {
             Ok(res) => res,
-            Err(winnow::Err::Incomplete(Needed::Size(_))) => {
+            Err(winnow::error::ErrMode::Incomplete(Needed::Size(_))) => {
                 let record_size = KeyId::size() + AsymLockedAccessKey::size();
                 let total_size = key_count as usize * record_size;
 
-                return Err(winnow::Err::Incomplete(Needed::new(
+                return Err(winnow::error::ErrMode::Incomplete(Needed::new(
                     total_size - input.len(),
                 )));
             }

--- a/src/codec/meta/meta_key.rs
+++ b/src/codec/meta/meta_key.rs
@@ -3,8 +3,9 @@ use std::ops::Deref;
 
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::AsyncWrite;
+use winnow::combinator::repeat;
 use winnow::error::Needed;
-use winnow::multi::count;
+
 use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, KeyId, SigningKey};
@@ -51,9 +52,9 @@ impl MetaKey {
         key_count: u8,
         signing_key: &SigningKey,
     ) -> ParserResult<'a, Option<Self>> {
-        let mut asym_parser = count(
-            (KeyId::parse, AsymLockedAccessKey::parse),
+        let mut asym_parser = repeat(
             key_count as usize,
+            (KeyId::parse, AsymLockedAccessKey::parse),
         );
 
         let (input, locked_keys): (_, Vec<_>) = match asym_parser.parse_next(input) {

--- a/src/codec/meta/meta_key.rs
+++ b/src/codec/meta/meta_key.rs
@@ -5,6 +5,7 @@ use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::AsyncWrite;
 use winnow::error::Needed;
 use winnow::multi::count;
+use winnow::Parser;
 
 use crate::codec::crypto::{AccessKey, AsymLockedAccessKey, KeyId, SigningKey};
 use crate::codec::header::KeyCount;
@@ -55,7 +56,7 @@ impl MetaKey {
             key_count as usize,
         );
 
-        let (input, locked_keys): (_, Vec<_>) = match asym_parser(input) {
+        let (input, locked_keys): (_, Vec<_>) = match asym_parser.parse_next(input) {
             Ok(res) => res,
             Err(winnow::error::ErrMode::Incomplete(Needed::Size(_))) => {
                 let record_size = KeyId::size() + AsymLockedAccessKey::size();

--- a/src/codec/meta/permanent_id.rs
+++ b/src/codec/meta/permanent_id.rs
@@ -1,6 +1,6 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
+use winnow::bytes::streaming::take;
 use rand::Rng;
 
 use crate::codec::ParserResult;

--- a/src/codec/meta/permanent_id.rs
+++ b/src/codec/meta/permanent_id.rs
@@ -1,7 +1,7 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use rand::Rng;
-use winnow::{bytes::take, Parser};
+use winnow::{token::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -28,7 +28,7 @@ impl PermanentId {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, id_bytes) = take(PERMANENT_ID_SIZE).parse_next(input)?;
+        let (remaining, id_bytes) = take(PERMANENT_ID_SIZE).parse_peek(input)?;
 
         let mut bytes = [0u8; PERMANENT_ID_SIZE];
         bytes.copy_from_slice(id_bytes);

--- a/src/codec/meta/permanent_id.rs
+++ b/src/codec/meta/permanent_id.rs
@@ -1,7 +1,7 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use rand::Rng;
-use winnow::bytes::take;
+use winnow::{bytes::take, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -28,7 +28,7 @@ impl PermanentId {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (remaining, id_bytes) = take(PERMANENT_ID_SIZE)(input)?;
+        let (remaining, id_bytes) = take(PERMANENT_ID_SIZE).parse_next(input)?;
 
         let mut bytes = [0u8; PERMANENT_ID_SIZE];
         bytes.copy_from_slice(id_bytes);

--- a/src/codec/meta/permanent_id.rs
+++ b/src/codec/meta/permanent_id.rs
@@ -1,9 +1,9 @@
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use winnow::bytes::streaming::take;
 use rand::Rng;
+use winnow::bytes::take;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 const PERMANENT_ID_SIZE: usize = 8;
 
@@ -27,7 +27,7 @@ impl PermanentId {
         Self(rng.gen())
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (remaining, id_bytes) = take(PERMANENT_ID_SIZE)(input)?;
 
         let mut bytes = [0u8; PERMANENT_ID_SIZE];

--- a/src/codec/meta/vector_clock.rs
+++ b/src/codec/meta/vector_clock.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use async_std::sync::RwLock;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u64;
+use winnow::number::le_u64;
 
-use crate::codec::ParserResult;
+use crate::codec::{ParserResult, Stream};
 
 #[derive(Clone, Debug)]
 pub struct VectorClock(Arc<RwLock<u64>>);
@@ -24,7 +24,7 @@ impl VectorClock {
         Self::from(0)
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, value) = le_u64(input)?;
         Ok((input, Self::from(value)))
     }

--- a/src/codec/meta/vector_clock.rs
+++ b/src/codec/meta/vector_clock.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_std::sync::RwLock;
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u64;
+use winnow::number::streaming::le_u64;
 
 use crate::codec::ParserResult;
 

--- a/src/codec/meta/vector_clock.rs
+++ b/src/codec/meta/vector_clock.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_std::sync::RwLock;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u64;
+use winnow::binary::le_u64;
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/codec/meta/vector_clock.rs
+++ b/src/codec/meta/vector_clock.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_std::sync::RwLock;
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::binary::le_u64;
+use winnow::{binary::le_u64, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -25,7 +25,7 @@ impl VectorClock {
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
-        let (input, value) = le_u64(input)?;
+        let (input, value) = le_u64.parse_peek(input)?;
         Ok((input, Self::from(value)))
     }
 

--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -21,7 +21,7 @@ pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 //    async fn next(input: &'a [u8], ctx: &'a Self::Context) -> ParserResult<'a, Option<Self>> {
 //        match Self::parse(input, ctx) {
 //            Ok((remaining, parsed)) => Ok((remaining, Some(parsed))),
-//            Err(winnow::Err::Incomplete(_)) => Ok((input, None)),
+//            Err(winnow::error::ErrMode::Incomplete(_)) => Ok((input, None)),
 //            Err(err) => Err(err),
 //        }
 //    }

--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -13,10 +13,10 @@ pub type Stream<'a> = Partial<&'a [u8]>;
 
 #[cfg(debug_assertions)]
 pub type ParserResult<'a, T> =
-    winnow::IResult<Stream<'a>, T, winnow::error::VerboseError<Stream<'a>>>;
+    winnow::IResult<Stream<'a>, T, winnow::error::ContextError<Stream<'a>>>;
 
 pub type CompleteParserResult<'a, T> =
-    winnow::IResult<&'a [u8], T, winnow::error::VerboseError<&'a [u8]>>;
+    winnow::IResult<&'a [u8], T, winnow::error::ContextError<&'a [u8]>>;
 
 #[cfg(not(debug_assertions))]
 pub type ParserResult<'a, T> = winnow::IResult<Stream<'a>, T>;

--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -9,10 +9,10 @@ pub(crate) use segment_streamer::SegmentStreamer;
 pub use state_error::StateError;
 
 #[cfg(debug_assertions)]
-pub type ParserResult<'a, T> = nom::IResult<&'a [u8], T, nom::error::VerboseError<&'a [u8]>>;
+pub type ParserResult<'a, T> = winnow::IResult<&'a [u8], T, winnow::error::VerboseError<&'a [u8]>>;
 
 #[cfg(not(debug_assertions))]
-pub type ParserResult<'a, T> = nom::IResult<&'a [u8], T>;
+pub type ParserResult<'a, T> = winnow::IResult<&'a [u8], T>;
 
 pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 
@@ -21,7 +21,7 @@ pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 //    async fn next(input: &'a [u8], ctx: &'a Self::Context) -> ParserResult<'a, Option<Self>> {
 //        match Self::parse(input, ctx) {
 //            Ok((remaining, parsed)) => Ok((remaining, Some(parsed))),
-//            Err(nom::Err::Incomplete(_)) => Ok((input, None)),
+//            Err(winnow::Err::Incomplete(_)) => Ok((input, None)),
 //            Err(err) => Err(err),
 //        }
 //    }

--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -7,12 +7,16 @@ pub use parser_state_machine::ParserStateMachine;
 pub use progress_type::ProgressType;
 pub(crate) use segment_streamer::SegmentStreamer;
 pub use state_error::StateError;
+use winnow::Partial;
+
+pub type Stream<'a> = Partial<&'a [u8]>;
 
 #[cfg(debug_assertions)]
-pub type ParserResult<'a, T> = winnow::IResult<&'a [u8], T, winnow::error::VerboseError<&'a [u8]>>;
+pub type ParserResult<'a, T> =
+    winnow::IResult<Stream<'a>, T, winnow::error::VerboseError<Stream<'a>>>;
 
 #[cfg(not(debug_assertions))]
-pub type ParserResult<'a, T> = winnow::IResult<&'a [u8], T>;
+pub type ParserResult<'a, T> = winnow::IResult<Stream<'a>, T>;
 
 pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 
@@ -30,10 +34,10 @@ pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 pub trait Parser: Sized {
     type Context: Send + Sync;
 
-    fn parse<'a>(input: &'a [u8], ctx: &'a Self::Context) -> ParserResult<'a, Self>;
+    fn parse<'a>(input: Stream<'a>, ctx: &'a Self::Context) -> ParserResult<'a, Self>;
 
     fn parse_many<'a>(
-        mut input: &'a [u8],
+        mut input: Stream<'a>,
         ctx: &'a Self::Context,
         count: usize,
     ) -> ParserResult<'a, Vec<Self>> {

--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -15,8 +15,13 @@ pub type Stream<'a> = Partial<&'a [u8]>;
 pub type ParserResult<'a, T> =
     winnow::IResult<Stream<'a>, T, winnow::error::VerboseError<Stream<'a>>>;
 
+pub type CompleteParserResult<'a, T> =
+    winnow::IResult<&'a [u8], T, winnow::error::VerboseError<&'a [u8]>>;
+
 #[cfg(not(debug_assertions))]
 pub type ParserResult<'a, T> = winnow::IResult<Stream<'a>, T>;
+#[cfg(not(debug_assertions))]
+pub type CompleteParserResult<'a, T> = winnow::IResult<&'a [u8], T>;
 
 pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 

--- a/src/codec/parser/parser_state_machine.rs
+++ b/src/codec/parser/parser_state_machine.rs
@@ -1,7 +1,9 @@
 use crate::codec::parser::{StateError, StateResult};
 
+use super::Stream;
+
 pub trait ParserStateMachine<T> {
     type Error: StateError;
 
-    fn parse(&mut self, buffer: &[u8]) -> StateResult<T, Self::Error>;
+    fn parse(&mut self, buffer: Stream) -> StateResult<T, Self::Error>;
 }

--- a/src/codec/parser/segment_streamer.rs
+++ b/src/codec/parser/segment_streamer.rs
@@ -34,7 +34,7 @@ impl<T: Unpin, S: ParserStateMachine<T>> SegmentStreamer<T, S> {
 
     pub async fn next(&mut self) -> Option<Result<(Hash, T), S::Error>> {
         loop {
-            match self.state_machine.parse(&self.buffer) {
+            match self.state_machine.parse(super::Stream::new(&self.buffer)) {
                 Ok(ProgressType::Ready(byte_count, val)) => {
                     let read_data = self.buffer.split_to(byte_count);
 

--- a/src/filesystem/content_reference.rs
+++ b/src/filesystem/content_reference.rs
@@ -1,6 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::multi::count;
-use nom::number::streaming::{le_u16, le_u64};
+use winnow::multi::count;
+use winnow::number::streaming::{le_u16, le_u64};
 
 use crate::codec::filesystem::BlockKind;
 use crate::codec::{BlockSize, Cid, ParserResult};

--- a/src/filesystem/content_reference.rs
+++ b/src/filesystem/content_reference.rs
@@ -1,6 +1,7 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::multi::count;
 use winnow::number::{le_u16, le_u64};
+use winnow::Parser;
 
 use crate::codec::filesystem::BlockKind;
 use crate::codec::{BlockSize, Cid, ParserResult, Stream};
@@ -77,7 +78,7 @@ impl ContentReference {
     }
 
     pub fn parse_many(input: Stream, ref_count: u8) -> ParserResult<Vec<Self>> {
-        count(Self::parse, ref_count as usize)(input)
+        count(Self::parse, ref_count as usize).parse_next(input)
     }
 
     pub fn size(&self) -> usize {
@@ -145,7 +146,7 @@ impl ContentLocation {
     }
 
     pub fn parse_many(input: Stream, ref_count: u16) -> ParserResult<Vec<Self>> {
-        count(Self::parse, ref_count as usize)(input)
+        count(Self::parse, ref_count as usize).parse_next(input)
     }
 
     pub fn size(&self) -> usize {

--- a/src/filesystem/content_reference.rs
+++ b/src/filesystem/content_reference.rs
@@ -1,6 +1,6 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::multi::count;
-use winnow::number::{le_u16, le_u64};
+use winnow::binary::{le_u16, le_u64};
+use winnow::combinator::repeat;
 use winnow::Parser;
 
 use crate::codec::filesystem::BlockKind;
@@ -78,7 +78,7 @@ impl ContentReference {
     }
 
     pub fn parse_many(input: Stream, ref_count: u8) -> ParserResult<Vec<Self>> {
-        count(Self::parse, ref_count as usize).parse_next(input)
+        repeat(ref_count as usize, Self::parse).parse_next(input)
     }
 
     pub fn size(&self) -> usize {
@@ -146,7 +146,7 @@ impl ContentLocation {
     }
 
     pub fn parse_many(input: Stream, ref_count: u16) -> ParserResult<Vec<Self>> {
-        count(Self::parse, ref_count as usize).parse_next(input)
+        repeat(ref_count as usize, Self::parse).parse_next(input)
     }
 
     pub fn size(&self) -> usize {

--- a/src/filesystem/content_reference.rs
+++ b/src/filesystem/content_reference.rs
@@ -1,9 +1,9 @@
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::multi::count;
-use winnow::number::streaming::{le_u16, le_u64};
+use winnow::number::{le_u16, le_u64};
 
 use crate::codec::filesystem::BlockKind;
-use crate::codec::{BlockSize, Cid, ParserResult};
+use crate::codec::{BlockSize, Cid, ParserResult, Stream};
 
 #[derive(Clone, Debug)]
 pub struct ContentReference {
@@ -60,7 +60,7 @@ impl ContentReference {
         Ok(written_bytes)
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, data_block_cid) = Cid::parse(input)?;
         let (input, block_size) = BlockSize::parse(input)?;
 
@@ -76,7 +76,7 @@ impl ContentReference {
         Ok((input, content_ref))
     }
 
-    pub fn parse_many(input: &[u8], ref_count: u8) -> ParserResult<Vec<Self>> {
+    pub fn parse_many(input: Stream, ref_count: u8) -> ParserResult<Vec<Self>> {
         count(Self::parse, ref_count as usize)(input)
     }
 
@@ -130,7 +130,7 @@ impl ContentLocation {
         Ok(written_bytes)
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, block_kind) = BlockKind::parse(input)?;
         let (input, content_cid) = Cid::parse(input)?;
         let (input, block_index) = le_u64(input)?;
@@ -144,7 +144,7 @@ impl ContentLocation {
         Ok((input, location))
     }
 
-    pub fn parse_many(input: &[u8], ref_count: u16) -> ParserResult<Vec<Self>> {
+    pub fn parse_many(input: Stream, ref_count: u16) -> ParserResult<Vec<Self>> {
         count(Self::parse, ref_count as usize)(input)
     }
 

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -53,16 +53,16 @@ impl DriveAccess {
 
         for _ in 0..key_count {
             let (i, key_id) = KeyId::parse(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
-                    input,
+                winnow::error::ErrMode::Cut(winnow::error::ParserError::from_error_kind(
+                    &input,
                     winnow::error::ErrorKind::Verify,
                 ))
             })?;
             buf_slice = i;
 
             let (i, settings) = ActorSettings::parse_private(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
-                    input,
+                winnow::error::ErrMode::Cut(winnow::error::ParserError::from_error_kind(
+                    &input,
                     winnow::error::ErrorKind::Verify,
                 ))
             })?;

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -53,12 +53,12 @@ impl DriveAccess {
 
         for _ in 0..key_count {
             let (i, key_id) = KeyId::parse(buf_slice).map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 
             let (i, settings) = ActorSettings::parse_private(buf_slice).map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -53,12 +53,12 @@ impl DriveAccess {
 
         for _ in 0..key_count {
             let (i, key_id) = KeyId::parse(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 
             let (i, settings) = ActorSettings::parse_private(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -6,7 +6,7 @@ use futures::io::AsyncWrite;
 
 use crate::codec::crypto::{KeyId, PermissionKeys, SigningKey, VerifyingKey};
 use crate::codec::header::KeyAccessSettings;
-use crate::codec::{ActorId, ActorSettings, ParserResult};
+use crate::codec::{ActorId, ActorSettings, ParserResult, Stream};
 
 #[derive(Clone, Debug)]
 pub struct DriveAccess {
@@ -42,7 +42,7 @@ impl DriveAccess {
     }
 
     pub fn parse<'a>(
-        input: &'a [u8],
+        input: Stream<'a>,
         key_count: u8,
         signing_key: &SigningKey,
     ) -> ParserResult<'a, Self> {
@@ -53,12 +53,18 @@ impl DriveAccess {
 
         for _ in 0..key_count {
             let (i, key_id) = KeyId::parse(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
+                    input,
+                    winnow::error::ErrorKind::Verify,
+                ))
             })?;
             buf_slice = i;
 
             let (i, settings) = ActorSettings::parse_private(buf_slice).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
+                    input,
+                    winnow::error::ErrorKind::Verify,
+                ))
             })?;
             buf_slice = i;
 

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -53,12 +53,12 @@ impl DriveAccess {
 
         for _ in 0..key_count {
             let (i, key_id) = KeyId::parse(buf_slice).map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 
             let (i, settings) = ActorSettings::parse_private(buf_slice).map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
             })?;
             buf_slice = i;
 

--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -425,12 +425,15 @@ impl DirectoryHandle {
 
                 let data_chunk = store.retrieve(content_ref.data_block_cid()).await?;
 
-                let (_remaining, block) =
-                    DataBlock::parse_with_magic(&data_chunk, &unlocked_key, &verifying_key)
-                        .map_err(|err| {
-                            tracing::error!("parsing of data block failed: {err:?}");
-                            OperationError::BlockCorrupted(content_ref.data_block_cid())
-                        })?;
+                let (_remaining, block) = DataBlock::parse_with_magic(
+                    Stream::new(&data_chunk),
+                    &unlocked_key,
+                    &verifying_key,
+                )
+                .map_err(|err| {
+                    tracing::error!("parsing of data block failed: {err:?}");
+                    OperationError::BlockCorrupted(content_ref.data_block_cid())
+                })?;
                 // todo(sstelfox): still stuff remaining which means this decoder is sloppy
                 //tracing::info!(?remaining, "drive::read::remaining");
                 //debug_assert!(remaining.is_empty(), "no extra data should be present");

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u64;
+use winnow::number::streaming::le_u64;
 use slab::Slab;
 use tracing::instrument;
 
@@ -274,9 +274,9 @@ impl InnerDrive {
                 if !permanent_id_map.contains_key(&pid) {
                     tracing::warn!(?permanent_id, child_pid = ?pid, "encountered child PID before parent");
 
-                    //return Err(nom::Err::Failure(nom::error::make_error(
+                    //return Err(winnow::Err::Cut(winnow::error::make_error(
                     //    node_input,
-                    //    nom::error::ErrorKind::Verify,
+                    //    winnow::error::ErrorKind::Verify,
                     //)));
                 }
             }
@@ -287,9 +287,9 @@ impl InnerDrive {
         }
 
         let root_node_id = *permanent_id_map.get(&root_pid).ok_or_else(|| {
-            nom::Err::Failure(nom::error::make_error(
+            winnow::Err::Cut(winnow::error::make_error(
                 node_input,
-                nom::error::ErrorKind::Verify,
+                winnow::error::ErrorKind::Verify,
             ))
         })?;
 

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -365,11 +365,10 @@ impl InnerDrive {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::OsRng;
-
-    use crate::prelude::NodeName;
-
     use self::crypto::Fingerprint;
+    use crate::prelude::NodeName;
+    use rand::rngs::OsRng;
+    use winnow::Partial;
 
     use super::*;
 
@@ -429,8 +428,13 @@ mod test {
         let encoding_res = inner.encode(&mut encoded).await;
         assert!(encoding_res.is_ok());
 
-        let (remaining, parsed) =
-            InnerDrive::parse(encoded.as_slice(), access.to_owned(), journal, None).unwrap();
+        let (remaining, parsed) = InnerDrive::parse(
+            Partial::new(encoded.as_slice()),
+            access.to_owned(),
+            journal,
+            None,
+        )
+        .unwrap();
         assert!(remaining.is_empty());
         assert_eq!(inner.nodes.len(), parsed.nodes.len());
         for (_, node) in inner.nodes {

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -274,7 +274,7 @@ impl InnerDrive {
                 if !permanent_id_map.contains_key(&pid) {
                     tracing::warn!(?permanent_id, child_pid = ?pid, "encountered child PID before parent");
 
-                    //return Err(winnow::Err::Cut(winnow::error::make_error(
+                    //return Err(winnow::error::ErrMode::Cut(winnow::error::make_error(
                     //    node_input,
                     //    winnow::error::ErrorKind::Verify,
                     //)));
@@ -287,7 +287,7 @@ impl InnerDrive {
         }
 
         let root_node_id = *permanent_id_map.get(&root_pid).ok_or_else(|| {
-            winnow::Err::Cut(winnow::error::make_error(
+            winnow::error::ErrMode::Cut(winnow::error::make_error(
                 node_input,
                 winnow::error::ErrorKind::Verify,
             ))

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -4,7 +4,7 @@ use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
 use slab::Slab;
 use tracing::instrument;
-use winnow::number::le_u64;
+use winnow::binary::le_u64;
 
 use crate::codec::crypto::AccessKey;
 use crate::codec::*;

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -2,9 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use ecdsa::signature::rand_core::CryptoRngCore;
 use futures::io::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::le_u64;
 use slab::Slab;
 use tracing::instrument;
+use winnow::number::le_u64;
 
 use crate::codec::crypto::AccessKey;
 use crate::codec::*;
@@ -242,7 +242,7 @@ impl InnerDrive {
     }
 
     pub(crate) fn parse<'a>(
-        input: &'a [u8],
+        input: Stream<'a>,
         drive_access: DriveAccess,
         journal_start: JournalCheckpoint,
         data_key: Option<&AccessKey>,

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -274,7 +274,7 @@ impl InnerDrive {
                 if !permanent_id_map.contains_key(&pid) {
                     tracing::warn!(?permanent_id, child_pid = ?pid, "encountered child PID before parent");
 
-                    //return Err(winnow::error::ErrMode::Cut(winnow::error::make_error(
+                    //return Err(winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
                     //    node_input,
                     //    winnow::error::ErrorKind::Verify,
                     //)));
@@ -287,7 +287,7 @@ impl InnerDrive {
         }
 
         let root_node_id = *permanent_id_map.get(&root_pid).ok_or_else(|| {
-            winnow::error::ErrMode::Cut(winnow::error::make_error(
+            winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
                 node_input,
                 winnow::error::ErrorKind::Verify,
             ))

--- a/src/filesystem/drive/loader.rs
+++ b/src/filesystem/drive/loader.rs
@@ -4,7 +4,7 @@ use async_std::sync::RwLock;
 use futures::{AsyncRead, AsyncReadExt};
 use tracing::{debug, trace};
 use winnow::error::ErrMode;
-use winnow::number::le_u64;
+use winnow::binary::le_u64;
 
 use crate::codec::crypto::{AuthenticationTag, EncryptedBuffer, Nonce, SigningKey};
 use crate::codec::header::{ContentOptions, IdentityHeader, KeyCount, PublicSettings};

--- a/src/filesystem/drive/loader.rs
+++ b/src/filesystem/drive/loader.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use async_std::sync::RwLock;
 use futures::{AsyncRead, AsyncReadExt};
-use nom::number::streaming::le_u64;
 use tracing::{debug, trace};
+use winnow::number::streaming::le_u64;
 
 use crate::codec::crypto::{AuthenticationTag, EncryptedBuffer, Nonce, SigningKey};
 use crate::codec::header::{ContentOptions, IdentityHeader, KeyCount, PublicSettings};
@@ -302,13 +302,13 @@ impl StateError for DriveLoaderError {
     }
 }
 
-impl<E: std::fmt::Debug> From<nom::Err<E>> for DriveLoaderError {
-    fn from(err: nom::Err<E>) -> Self {
+impl<E: std::fmt::Debug> From<winnow::Err<E>> for DriveLoaderError {
+    fn from(err: winnow::Err<E>) -> Self {
         match err {
-            nom::Err::Incomplete(nom::Needed::Size(n)) => {
+            winnow::Err::Incomplete(winnow::error::Needed::Size(n)) => {
                 DriveLoaderError::Incomplete(Some(n.get()))
             }
-            nom::Err::Incomplete(_) => DriveLoaderError::Incomplete(None),
+            winnow::Err::Incomplete(_) => DriveLoaderError::Incomplete(None),
             err => {
                 let err_msg = format!("parse verification detected failure: {:?}", err);
                 DriveLoaderError::ParserFailure(err_msg)

--- a/src/filesystem/drive/loader.rs
+++ b/src/filesystem/drive/loader.rs
@@ -11,6 +11,7 @@ use crate::codec::meta::{FilesystemId, JournalCheckpoint, MetaKey};
 use crate::codec::parser::{
     ParserResult, ParserStateMachine, ProgressType, SegmentStreamer, StateError, StateResult,
 };
+use crate::codec::Stream;
 use crate::filesystem::{Drive, DriveAccess, InnerDrive};
 
 pub struct DriveLoader<'a> {
@@ -66,7 +67,7 @@ impl<'a> DriveLoader<'a> {
 impl ParserStateMachine<Drive> for DriveLoader<'_> {
     type Error = DriveLoaderError;
 
-    fn parse(&mut self, buffer: &[u8]) -> StateResult<Drive, Self::Error> {
+    fn parse(&mut self, buffer: Stream) -> StateResult<Drive, Self::Error> {
         match &self.state {
             DriveLoaderState::IdentityHeader => {
                 let (input, id_header) = IdentityHeader::parse_with_magic(buffer)?;
@@ -155,7 +156,7 @@ impl ParserStateMachine<Drive> for DriveLoader<'_> {
                     "drive_loader::encrypted_header"
                 );
 
-                let mut header = header_buffer.as_ref();
+                let mut header = header_buffer.as_slice();
 
                 let (remaining, drive_access) =
                     DriveAccess::parse(header, **key_count, self.signing_key)?;

--- a/src/filesystem/drive/loader.rs
+++ b/src/filesystem/drive/loader.rs
@@ -302,13 +302,13 @@ impl StateError for DriveLoaderError {
     }
 }
 
-impl<E: std::fmt::Debug> From<winnow::Err<E>> for DriveLoaderError {
-    fn from(err: winnow::Err<E>) -> Self {
+impl<E: std::fmt::Debug> From<winnow::error::ErrMode<E>> for DriveLoaderError {
+    fn from(err: winnow::error::ErrMode<E>) -> Self {
         match err {
-            winnow::Err::Incomplete(winnow::error::Needed::Size(n)) => {
+            winnow::error::ErrMode::Incomplete(winnow::error::Needed::Size(n)) => {
                 DriveLoaderError::Incomplete(Some(n.get()))
             }
-            winnow::Err::Incomplete(_) => DriveLoaderError::Incomplete(None),
+            winnow::error::ErrMode::Incomplete(_) => DriveLoaderError::Incomplete(None),
             err => {
                 let err_msg = format!("parse verification detected failure: {:?}", err);
                 DriveLoaderError::ParserFailure(err_msg)

--- a/src/filesystem/drive/mod.rs
+++ b/src/filesystem/drive/mod.rs
@@ -221,7 +221,6 @@ pub enum DriveError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/src/filesystem/file_content.rs
+++ b/src/filesystem/file_content.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::{le_u64, le_u8};
+use winnow::binary::{le_u64, le_u8};
 
 use crate::codec::crypto::SymLockedAccessKey;
 use crate::codec::{Cid, ParserResult, Stream};

--- a/src/filesystem/file_content.rs
+++ b/src/filesystem/file_content.rs
@@ -1,8 +1,8 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::{le_u64, le_u8};
+use winnow::number::{le_u64, le_u8};
 
 use crate::codec::crypto::SymLockedAccessKey;
-use crate::codec::{Cid, ParserResult};
+use crate::codec::{Cid, ParserResult, Stream};
 use crate::filesystem::ContentReference;
 
 const FILE_CONTENT_TYPE_STUB: u8 = 0x01;
@@ -148,7 +148,7 @@ impl FileContent {
         matches!(self, Self::Stub { .. })
     }
 
-    pub fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, content_type) = le_u8(input)?;
 
         let parsed = match content_type {
@@ -189,7 +189,10 @@ impl FileContent {
                 (input, data)
             }
             _ => {
-                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Tag);
+                let err = winnow::error::ParseError::from_error_kind(
+                    input,
+                    winnow::error::ErrorKind::Tag,
+                );
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };

--- a/src/filesystem/file_content.rs
+++ b/src/filesystem/file_content.rs
@@ -190,7 +190,7 @@ impl FileContent {
             }
             _ => {
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Tag);
-                return Err(winnow::Err::Cut(err));
+                return Err(winnow::error::ErrMode::Cut(err));
             }
         };
 

--- a/src/filesystem/file_content.rs
+++ b/src/filesystem/file_content.rs
@@ -1,5 +1,5 @@
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::{le_u64, le_u8};
+use winnow::number::streaming::{le_u64, le_u8};
 
 use crate::codec::crypto::SymLockedAccessKey;
 use crate::codec::{Cid, ParserResult};
@@ -189,8 +189,8 @@ impl FileContent {
                 (input, data)
             }
             _ => {
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Tag);
-                return Err(nom::Err::Failure(err));
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Tag);
+                return Err(winnow::Err::Cut(err));
             }
         };
 

--- a/src/filesystem/file_content.rs
+++ b/src/filesystem/file_content.rs
@@ -189,7 +189,7 @@ impl FileContent {
                 (input, data)
             }
             _ => {
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Tag);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Tag);
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -28,8 +28,8 @@ use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::binary::{le_i64, le_u32, le_u8};
-use winnow::token::take;
 use winnow::stream::Offset;
+use winnow::token::take;
 use winnow::Parser;
 
 use crate::codec::crypto::AccessKey;
@@ -357,9 +357,9 @@ impl Node {
             input = meta_buf;
         }
 
-        let (remaining, inner) = NodeData::parse(input)?;
+        let (input, inner) = NodeData::parse(input)?;
         debug_assert!(
-            node_data_start.offset_from(&remaining) == usize::try_from(node_data_len).unwrap(), //Unwrap safe on 32bit and up systems (unsafe on 16 bit systems)
+            input.offset_from(&node_data_start) == usize::try_from(node_data_len).unwrap(), //Unwrap safe on 32bit and up systems (unsafe on 16 bit systems)
             "did not consume all input"
         );
 

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -266,7 +266,7 @@ impl Node {
                 (node_data_buf, Some(pid))
             }
             _ => {
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Switch);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Switch);
                 return Err(winnow::error::ErrMode::Cut(err));
             }
         };
@@ -282,7 +282,7 @@ impl Node {
             let (meta_buf, key_len) = le_u8(node_data_buf)?;
             let (meta_buf, key) = take(key_len)(meta_buf)?;
             let key_str = String::from_utf8(key.to_vec()).map_err(|_| {
-                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Char))
+                winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Char))
             })?;
 
             let (meta_buf, val_len) = le_u8(meta_buf)?;

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -16,7 +16,7 @@ use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::bytes::take;
-use winnow::number::{le_i64, le_u32, le_u8};
+use winnow::binary::{le_i64, le_u32, le_u8};
 
 use crate::codec::crypto::AccessKey;
 use crate::codec::filesystem::NodeKind;

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -13,8 +13,8 @@ use std::collections::HashMap;
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::bytes::streaming::take;
-use nom::number::streaming::{le_i64, le_u32, le_u8};
+use winnow::bytes::streaming::take;
+use winnow::number::streaming::{le_i64, le_u32, le_u8};
 
 use crate::codec::crypto::AccessKey;
 use crate::codec::filesystem::NodeKind;
@@ -266,8 +266,8 @@ impl Node {
                 (node_data_buf, Some(pid))
             }
             _ => {
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Switch);
-                return Err(nom::Err::Failure(err));
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Switch);
+                return Err(winnow::Err::Cut(err));
             }
         };
 
@@ -282,7 +282,7 @@ impl Node {
             let (meta_buf, key_len) = le_u8(node_data_buf)?;
             let (meta_buf, key) = take(key_len)(meta_buf)?;
             let key_str = String::from_utf8(key.to_vec()).map_err(|_| {
-                nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Char))
+                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Char))
             })?;
 
             let (meta_buf, val_len) = le_u8(meta_buf)?;

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use node_builder::{NodeBuilder, NodeBuilderError};
 
 pub use node_data::{NodeData, NodeDataError};
 pub use node_name::{NodeName, NodeNameError};
+use winnow::Parser;
 
 use std::collections::HashMap;
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
@@ -253,12 +254,15 @@ impl Node {
         let (input, node_data_len) = le_u32(input)?;
         tracing::trace!(node_data_len, ?cid, "cid/node_data_len");
 
-        let (input, node_data_buf) = take(node_data_len)(input)?;
+        // let (input, node_data_buf) = take(node_data_len)(input)?;
 
-        let (node_data_buf, permanent_id) = PermanentId::parse(node_data_buf)?;
-        let (node_data_buf, vector_clock) = VectorClock::parse(node_data_buf)?;
+        let (input, (permanent_id, vector_clock, parent_present)) =
+            (PermanentId::parse, VectorClock::parse, take(1u8)).parse_next(input)?;
 
-        let (node_data_buf, parent_present) = take(1u8)(node_data_buf)?;
+        // let (node_data_buf, permanent_id) = PermanentId::parse(node_data_buf)?;
+        // let (node_data_buf, vector_clock) = VectorClock::parse(node_data_buf)?;
+
+        // let (node_data_buf, parent_present) = take(1u8)(node_data_buf)?;
         let (node_data_buf, parent_id) = match parent_present[0] {
             0x00 => (node_data_buf, None),
             0x01 => {

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -267,7 +267,7 @@ impl Node {
             }
             _ => {
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Switch);
-                return Err(winnow::Err::Cut(err));
+                return Err(winnow::error::ErrMode::Cut(err));
             }
         };
 
@@ -282,7 +282,7 @@ impl Node {
             let (meta_buf, key_len) = le_u8(node_data_buf)?;
             let (meta_buf, key) = take(key_len)(meta_buf)?;
             let key_str = String::from_utf8(key.to_vec()).map_err(|_| {
-                winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Char))
+                winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Char))
             })?;
 
             let (meta_buf, val_len) = le_u8(meta_buf)?;

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -277,7 +277,7 @@ impl Node {
             _ => {
                 let err = winnow::error::ParseError::from_error_kind(
                     input,
-                    winnow::error::ErrorKind::Switch,
+                    winnow::error::ErrorKind::Token,
                 );
                 return Err(winnow::error::ErrMode::Cut(err));
             }
@@ -295,16 +295,16 @@ impl Node {
         let mut metadata = HashMap::new();
         for _ in 0..metadata_entries {
             let (meta_buf, key_len) = le_u8(input)?;
-            let (meta_buf, key) = take(key_len)(meta_buf)?;
+            let (meta_buf, key) = take(key_len).parse_next(meta_buf)?;
             let key_str = String::from_utf8(key.to_vec()).map_err(|_| {
                 winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(
                     input,
-                    winnow::error::ErrorKind::Char,
+                    winnow::error::ErrorKind::Token,
                 ))
             })?;
 
             let (meta_buf, val_len) = le_u8(meta_buf)?;
-            let (meta_buf, val) = take(val_len)(meta_buf)?;
+            let (meta_buf, val) = take(val_len).parse_next(meta_buf)?;
             let val = val.to_vec();
 
             metadata.insert(key_str, val);

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -257,12 +257,14 @@ impl Node {
         let node_data_start = input;
 
         // let (input, node_data_buf) = take(node_data_len)(input)?;
+        // Need to add check for error conditions here (i.e. don't try to parse past `node_data_len`)
 
-        // let (node_data_buf, permanent_id) = PermanentId::parse(node_data_buf)?;
-        // let (node_data_buf, vector_clock) = VectorClock::parse(node_data_buf)?;
+        let (input, permanent_id) = PermanentId::parse(input)?;
+        let (input, vector_clock) = VectorClock::parse(input)?;
+        let (input, parent_present) = take(1u8).parse_next(input)?;
 
-        let (input, (permanent_id, vector_clock, parent_present)) =
-            (PermanentId::parse, VectorClock::parse, take(1u8)).parse_next(input)?;
+        // , vector_clock, parent_present)) =
+        //     (PermanentId::parse, VectorClock::parse, take(1u8)).parse_next(input)?;
         tracing::trace!(node_data_len, ?cid, "cid/node_data_len");
 
         // let (node_data_buf, parent_present) = take(1u8)(node_data_buf)?;
@@ -281,14 +283,14 @@ impl Node {
             }
         };
 
-        // let (node_data_buf, owner_id) = ActorId::parse(node_data_buf)?;
-        // let (node_data_buf, created_at) = le_i64(node_data_buf)?;
-        // let (node_data_buf, modified_at) = le_i64(node_data_buf)?;
-        // let (node_data_buf, name) = NodeName::parse(node_data_buf)?;
-        // let (mut node_data_buf, metadata_entries) = le_u8(node_data_buf)?;
+        let (input, owner_id) = ActorId::parse(input)?;
+        let (input, created_at) = le_i64(input)?;
+        let (input, modified_at) = le_i64(input)?;
+        let (input, name) = NodeName::parse(input)?;
+        let (mut input, metadata_entries) = le_u8(input)?;
 
-        let (input, (owner_id, created_at, modified_at, name, metadata_entries)) =
-            (ActorId::parse, le_i64, le_i64, NodeName::parse, le_u8).parse_next(input)?;
+        // let (input, (owner_id, created_at, modified_at, name, metadata_entries)) =
+        //     (ActorId::parse, le_i64, le_i64, NodeName::parse, le_u8).parse_next(input)?;
 
         let mut metadata = HashMap::new();
         for _ in 0..metadata_entries {

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -302,18 +302,12 @@ impl Node {
 
         let node_data_start = input;
 
-        // let (input, node_data_buf) = take(node_data_len)(input)?;
-        // Need to add check for error conditions here (i.e. don't try to parse past `node_data_len`)
-
         let (input, permanent_id) = PermanentId::parse(input)?;
         let (input, vector_clock) = VectorClock::parse(input)?;
         let (input, parent_present) = take(1u8).parse_peek(input)?;
 
-        // , vector_clock, parent_present)) =
-        //     (PermanentId::parse, VectorClock::parse, take(1u8)).parse_next(input)?;
         tracing::trace!(node_data_len, ?cid, "cid/node_data_len");
 
-        // let (node_data_buf, parent_present) = take(1u8)(node_data_buf)?;
         let (input, parent_id) = match parent_present[0] {
             0x00 => (input, None),
             0x01 => {
@@ -334,9 +328,6 @@ impl Node {
         let (input, modified_at) = le_i64.parse_peek(input)?;
         let (input, name) = NodeName::parse(input)?;
         let (mut input, metadata_entries) = le_u8.parse_peek(input)?;
-
-        // let (input, (owner_id, created_at, modified_at, name, metadata_entries)) =
-        //     (ActorId::parse, le_i64, le_i64, NodeName::parse, le_u8).parse_next(input)?;
 
         let mut metadata = HashMap::new();
         for _ in 0..metadata_entries {
@@ -360,7 +351,7 @@ impl Node {
         let (input, inner) = NodeData::parse(input)?;
         debug_assert!(
             input.offset_from(&node_data_start) == usize::try_from(node_data_len).unwrap(), //Unwrap safe on 32bit and up systems (unsafe on 16 bit systems)
-            "did not consume all input"
+            "consumed to little or too much during parse based on the node's data_len field"
         );
 
         let node = Self {

--- a/src/filesystem/nodes/node_data.rs
+++ b/src/filesystem/nodes/node_data.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use futures::{AsyncWrite, AsyncWriteExt};
 use winnow::binary::{le_u16, le_u64};
+use winnow::Parser;
 
 use crate::codec::filesystem::{DirectoryPermissions, FilePermissions};
 use crate::codec::{Cid, ParserResult, PermanentId, Stream};
@@ -149,7 +150,7 @@ impl NodeData {
             //NodeKind::AssociatedData => {}
             NodeKind::Directory => {
                 let (data_buf, permissions) = DirectoryPermissions::parse(input)?;
-                let (data_buf, children_size) = le_u64(data_buf)?;
+                let (data_buf, children_size) = le_u64.parse_peek(data_buf)?;
                 let (data_buf, children) = parse_children(data_buf)?;
 
                 let data = NodeData::Directory {
@@ -282,7 +283,7 @@ async fn encode_children<W: AsyncWrite + Unpin + Send>(
 }
 
 fn parse_children(input: Stream) -> ParserResult<HashMap<NodeName, PermanentId>> {
-    let (data_buf, children_count) = le_u16(input)?;
+    let (data_buf, children_count) = le_u16.parse_peek(input)?;
 
     let mut children = HashMap::new();
     let mut child_buf = data_buf;

--- a/src/filesystem/nodes/node_data.rs
+++ b/src/filesystem/nodes/node_data.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::{le_u16, le_u64};
+use winnow::number::streaming::{le_u16, le_u64};
 
 use crate::codec::filesystem::{DirectoryPermissions, FilePermissions};
 use crate::codec::{Cid, ParserResult, PermanentId};

--- a/src/filesystem/nodes/node_data.rs
+++ b/src/filesystem/nodes/node_data.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::{le_u16, le_u64};
+use winnow::binary::{le_u16, le_u64};
 
 use crate::codec::filesystem::{DirectoryPermissions, FilePermissions};
 use crate::codec::{Cid, ParserResult, PermanentId, Stream};

--- a/src/filesystem/nodes/node_data.rs
+++ b/src/filesystem/nodes/node_data.rs
@@ -2,10 +2,10 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::streaming::{le_u16, le_u64};
+use winnow::number::{le_u16, le_u64};
 
 use crate::codec::filesystem::{DirectoryPermissions, FilePermissions};
-use crate::codec::{Cid, ParserResult, PermanentId};
+use crate::codec::{Cid, ParserResult, PermanentId, Stream};
 use crate::filesystem::nodes::{NodeKind, NodeName};
 use crate::filesystem::FileContent;
 
@@ -129,7 +129,7 @@ impl NodeData {
         }
     }
 
-    pub(crate) fn parse(input: &[u8]) -> ParserResult<Self> {
+    pub(crate) fn parse(input: Stream) -> ParserResult<Self> {
         let (input, kind) = NodeKind::parse(input)?;
 
         match kind {
@@ -281,7 +281,7 @@ async fn encode_children<W: AsyncWrite + Unpin + Send>(
     Ok(written_bytes)
 }
 
-fn parse_children(input: &[u8]) -> ParserResult<HashMap<NodeName, PermanentId>> {
+fn parse_children(input: Stream) -> ParserResult<HashMap<NodeName, PermanentId>> {
     let (data_buf, children_count) = le_u16(input)?;
 
     let mut children = HashMap::new();

--- a/src/filesystem/nodes/node_name.rs
+++ b/src/filesystem/nodes/node_name.rs
@@ -1,7 +1,7 @@
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::{number::le_u8, Parser};
+use winnow::{binary::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 

--- a/src/filesystem/nodes/node_name.rs
+++ b/src/filesystem/nodes/node_name.rs
@@ -1,7 +1,7 @@
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use nom::number::streaming::le_u8;
+use winnow::number::streaming::le_u8;
 
 use crate::codec::ParserResult;
 
@@ -94,16 +94,16 @@ impl NodeName {
             NAME_TYPE_ROOT_ID => Ok((input, Self::Root)),
             NAME_TYPE_NAMED_ID => {
                 let (input, name_length) = le_u8(input)?;
-                let (input, name) = nom::bytes::streaming::take(name_length as usize)(input)?;
+                let (input, name) = winnow::bytes::streaming::take(name_length as usize)(input)?;
 
                 let name = String::from_utf8(name.to_vec()).map_err(|_| {
-                    nom::Err::Failure(nom::error::make_error(input, nom::error::ErrorKind::Verify))
+                    winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
                 })?;
                 Ok((input, Self::Named(name)))
             }
             _ => {
-                let err = nom::error::make_error(input, nom::error::ErrorKind::Verify);
-                Err(nom::Err::Failure(err))
+                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                Err(winnow::Err::Cut(err))
             }
         }
     }

--- a/src/filesystem/nodes/node_name.rs
+++ b/src/filesystem/nodes/node_name.rs
@@ -97,13 +97,13 @@ impl NodeName {
                 let (input, name) = winnow::bytes::streaming::take(name_length as usize)(input)?;
 
                 let name = String::from_utf8(name.to_vec()).map_err(|_| {
-                    winnow::Err::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                    winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
                 })?;
                 Ok((input, Self::Named(name)))
             }
             _ => {
                 let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
-                Err(winnow::Err::Cut(err))
+                Err(winnow::error::ErrMode::Cut(err))
             }
         }
     }

--- a/src/filesystem/nodes/node_name.rs
+++ b/src/filesystem/nodes/node_name.rs
@@ -97,12 +97,12 @@ impl NodeName {
                 let (input, name) = winnow::bytes::streaming::take(name_length as usize)(input)?;
 
                 let name = String::from_utf8(name.to_vec()).map_err(|_| {
-                    winnow::error::ErrMode::Cut(winnow::error::make_error(input, winnow::error::ErrorKind::Verify))
+                    winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify))
                 })?;
                 Ok((input, Self::Named(name)))
             }
             _ => {
-                let err = winnow::error::make_error(input, winnow::error::ErrorKind::Verify);
+                let err = winnow::error::ParseError::from_error_kind(input, winnow::error::ErrorKind::Verify);
                 Err(winnow::error::ErrMode::Cut(err))
             }
         }

--- a/src/filesystem/nodes/node_name.rs
+++ b/src/filesystem/nodes/node_name.rs
@@ -1,7 +1,7 @@
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use winnow::number::le_u8;
+use winnow::{number::le_u8, Parser};
 
 use crate::codec::{ParserResult, Stream};
 
@@ -94,7 +94,7 @@ impl NodeName {
             NAME_TYPE_ROOT_ID => Ok((input, Self::Root)),
             NAME_TYPE_NAMED_ID => {
                 let (input, name_length) = le_u8(input)?;
-                let (input, name) = winnow::bytes::take(name_length as usize)(input)?;
+                let (input, name) = winnow::bytes::take(name_length as usize).parse_next(input)?;
 
                 let name = String::from_utf8(name.to_vec()).map_err(|_| {
                     winnow::error::ErrMode::Cut(winnow::error::ParseError::from_error_kind(


### PR DESCRIPTION
This PR converts all usage of `nom` to `winnow`. While it preserves all existing functionality there is additional work to do to fully commit to their model of parsing (specifically see all the calls to parse_peek and unpeek). An additional ticket was made to capture that work: https://linear.app/banyan/issue/ENG-662/continue-winnow-transition


On major advantage this gets us is better debug output from the parser. To see this you need to enable the `debug` feature in winnow. For eaxmple this runs one of our tests with that feature enabled:
`cargo test --features winnow/debug --package banyanfs --lib -- filesystem::drive::inner::test::encode_to_parse`