### PR TITLE
Fix regreression from winnow port

### DIFF
--- a/src/codec/header/data_block.rs
+++ b/src/codec/header/data_block.rs
@@ -235,7 +235,7 @@ impl DataBlock {
             let (input, tag) = AuthenticationTag::parse(input)?;
 
             debug_assert!(
-                chunk_start.offset_from(&input) == base_chunk_size,
+                input.offset_from(&chunk_start) == base_chunk_size,
                 "chunk should be fully read"
             );
 


### PR DESCRIPTION
Fixes a panic caused by incorrectly ordered arguments to the `offset_from` function