### PR TITLE
Initialize the CID cache from the known CID

### DIFF
--- a/src/filesystem/nodes/cid_cache.rs
+++ b/src/filesystem/nodes/cid_cache.rs
@@ -57,6 +57,18 @@ impl CidCache {
     }
 }
 
+impl From<Cid> for CidCache {
+    fn from(cid: Cid) -> Self {
+        let inner = InnerCidCache {
+            dirty: false,
+            cid: Some(cid),
+            encoded: None,
+        };
+
+        Self(Arc::new(RwLock::new(inner)))
+    }
+}
+
 struct InnerCidCache {
     dirty: bool,
     cid: Option<Cid>,


### PR DESCRIPTION
This adjusts the parsing to prevent over-encoding when we want to access the CID of unchanged data. Thanks @jscatena88 for pointing this out.