### PR TITLE
feat(eng-673): Cids are affected by cids of their children

### DIFF
--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -306,7 +306,7 @@ impl DirectoryHandle {
         let src_parent_perm_id = inner_write.by_id(src_node_id)?.parent_id().ok_or(
             OperationError::InternalCorruption(src_node_id, "src node has no parent"),
         )?;
-        let src_parent_node = inner_write.by_perm_id_mut(&src_parent_perm_id)?;
+        let src_parent_node = inner_write.by_perm_id_mut(&src_parent_perm_id).await?;
 
         // Remove target node from its current location by removing it as a child from its parent
         src_parent_node
@@ -323,14 +323,14 @@ impl DirectoryHandle {
         // good way to make the move an atomic operation though...
         // The borrow checker won't let us get mutable references to all three nodes at once (src, dst, src_parent)
         // We could maybe extend `DriveInner` to do this operation internally to make it more atomic
-        let dst_parent_node = inner_write.by_id_mut(dst_parent_id)?;
+        let dst_parent_node = inner_write.by_id_mut(dst_parent_id).await?;
         let dst_parent_node_perm_id = dst_parent_node.permanent_id();
 
         dst_parent_node
             .add_child(new_dst_name.clone(), src_node_perm_id)
             .await?;
 
-        let src_node = inner_write.by_id_mut(src_node_id)?;
+        let src_node = inner_write.by_id_mut(src_node_id).await?;
         src_node.set_parent_id(dst_parent_node_perm_id).await;
         src_node.set_name(new_dst_name).await;
 
@@ -652,7 +652,7 @@ impl DirectoryHandle {
             .map_err(|_| OperationError::Other("failed to seal node data key"))?;
 
         let mut inner_write = self.inner.write().await;
-        let node = inner_write.by_perm_id_mut(&new_permanent_id)?;
+        let node = inner_write.by_perm_id_mut(&new_permanent_id).await?;
         let node_data = node.data_mut().await;
 
         let file_content =

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -89,13 +89,14 @@ impl InnerDrive {
         while let Some(parent_perm_id) = self.by_id(node_id)?.parent_id() {
             node_id = self.lookup_internal_id(&parent_perm_id)?;
             self.dirty_nodes.push(node_id);
+
+            let _node_mut = self //mark cid dirty (getting mutable access to its data will cause this)
+                .nodes
+                .get_mut(node_id)
+                .expect("This succeeded directly above in non-mut form")
+                .data_mut()
+                .await;
         }
-        let _node_mut = self //mark cid dirty (getting mutable access to its data will cause this)
-            .nodes
-            .get_mut(node_id)
-            .expect("This succeeded directly above in non-mut form")
-            .data_mut()
-            .await;
         Ok(())
     }
 

--- a/src/filesystem/nodes/cid_cache.rs
+++ b/src/filesystem/nodes/cid_cache.rs
@@ -49,6 +49,7 @@ impl CidCache {
         let cid = crate::utils::calculate_cid(data);
         let mut inner = self.0.write().await;
         inner.cid = Some(cid);
+        inner.dirty = false;
     }
 
     pub(crate) async fn take_cached(&self) -> Option<Vec<u8>> {

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -471,3 +471,26 @@ impl std::fmt::Debug for Node {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::codec::crypto::Fingerprint;
+
+    use super::*;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn test_mut_data_access_marks_cid_dirty() {
+        let mut rng = crate::utils::crypto_rng();
+        let mut test_node = NodeBuilder::file(NodeName::Named("TestDir".into()))
+            .with_id(0)
+            .with_owner(ActorId::from(Fingerprint::from([0; Fingerprint::size()])))
+            .with_parent(PermanentId::generate(&mut rng))
+            .build(&mut rng)
+            .unwrap();
+        let _cid = test_node.cid().await.unwrap();
+        assert!(!test_node.cid.is_dirty().await);
+        let _mut_data = test_node.data_mut().await;
+        assert!(test_node.cid.is_dirty().await);
+    }
+}

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -94,8 +94,9 @@ impl Node {
         &mut self,
         name: NodeName,
         child_id: PermanentId,
+        child_cid: Cid,
     ) -> Result<(), NodeDataError> {
-        self.inner.add_child(name, child_id)?;
+        self.inner.add_child(name, child_id, child_cid)?;
         self.notify_of_change().await;
 
         Ok(())

--- a/src/filesystem/nodes/node_data/child_map.rs
+++ b/src/filesystem/nodes/node_data/child_map.rs
@@ -1,0 +1,46 @@
+use crate::codec::{ParserResult, Stream};
+use futures::io::AsyncWrite;
+use std::collections::HashMap;
+
+use crate::{
+    codec::{Cid, PermanentId},
+    prelude::nodes::NodeName,
+};
+
+pub(crate) type ChildMap = HashMap<NodeName, ChildMapEntry>;
+
+pub(crate) struct ChildMapEntry {
+    permanent_id: PermanentId,
+    cid: Cid,
+}
+
+impl ChildMapEntry {
+    pub fn new(permanent_id: PermanentId, cid: Cid) -> Self {
+        Self { permanent_id, cid }
+    }
+
+    pub fn permanent_id(&self) -> &PermanentId {
+        &self.permanent_id
+    }
+
+    pub fn cid(&self) -> &Cid {
+        &self.cid
+    }
+
+    pub fn set_cid(&mut self, cid: Cid) {
+        self.cid = cid;
+    }
+
+    pub async fn encode<W: AsyncWrite + Unpin + Send>(
+        &self,
+        writer: &mut W,
+    ) -> std::io::Result<usize> {
+        Ok(self.permanent_id().encode(writer).await? + self.cid().encode(writer).await?)
+    }
+
+    pub fn parse(input: Stream) -> ParserResult<Self> {
+        let (input, id) = PermanentId::parse(input)?;
+        let (input, cid) = Cid::parse(input)?;
+        Ok((input, Self::new(id, cid)))
+    }
+}

--- a/src/filesystem/nodes/node_data/mod.rs
+++ b/src/filesystem/nodes/node_data/mod.rs
@@ -10,10 +10,15 @@ use crate::codec::{Cid, ParserResult, PermanentId, Stream};
 use crate::filesystem::nodes::{NodeKind, NodeName};
 use crate::filesystem::FileContent;
 
+mod child_map;
+use child_map::ChildMap;
+
+use self::child_map::ChildMapEntry;
+
 pub enum NodeData {
     File {
         permissions: FilePermissions,
-        associated_data: HashMap<NodeName, PermanentId>,
+        associated_data: ChildMap,
         content: FileContent,
     },
     #[allow(dead_code)]
@@ -21,7 +26,7 @@ pub enum NodeData {
     Directory {
         permissions: DirectoryPermissions,
         children_size: u64,
-        children: HashMap<NodeName, PermanentId>,
+        children: ChildMap,
     },
 }
 
@@ -30,6 +35,7 @@ impl NodeData {
         &mut self,
         name: NodeName,
         id: PermanentId,
+        cid: Cid,
     ) -> Result<(), NodeDataError> {
         let child_map = match self {
             NodeData::Directory { children, .. } => children,
@@ -40,13 +46,32 @@ impl NodeData {
         };
 
         match child_map.entry(name) {
-            Entry::Occupied(_) => return Err(NodeDataError::NameExists),
+            Entry::Occupied(_) => return Err(NodeDataError::ChildNameExists),
             Entry::Vacant(entry) => {
-                entry.insert(id);
+                entry.insert(ChildMapEntry::new(id, cid));
             }
         }
 
         Ok(())
+    }
+
+    pub fn update_child_cid(
+        &mut self,
+        child_permanent_id: &PermanentId,
+        cid: Cid,
+    ) -> Result<(), NodeDataError> {
+        match self {
+            Self::Directory { children, .. } => {
+                let child = children
+                    .iter_mut()
+                    .find(|entry| entry.1.permanent_id() == child_permanent_id)
+                    .ok_or(NodeDataError::ChildIdMissing)?
+                    .1;
+                child.set_cid(cid);
+                Ok(())
+            }
+            _ => Ok(()),
+        }
     }
 
     #[tracing::instrument(skip(self, writer))]
@@ -116,8 +141,11 @@ impl NodeData {
         };
 
         let mut child_pairs = children.iter().collect::<Vec<_>>();
-        child_pairs.sort_by(|(_, a), (_, b)| a.cmp(b));
-        child_pairs.into_iter().map(|(_, id)| *id).collect()
+        child_pairs.sort_by(|(_, a), (_, b)| a.permanent_id().cmp(b.permanent_id()));
+        child_pairs
+            .into_iter()
+            .map(|(_, id)| *id.permanent_id())
+            .collect()
     }
 
     pub(crate) fn data_cids(&self) -> Option<Vec<Cid>> {
@@ -174,8 +202,8 @@ impl NodeData {
         };
 
         match child_map.remove(name) {
-            Some(id) => Ok(id),
-            None => Err(NodeDataError::NameMissing),
+            Some(id) => Ok(id.permanent_id().clone()),
+            None => Err(NodeDataError::ChildNameMissing),
         }
     }
 
@@ -198,7 +226,7 @@ impl NodeData {
             _ => return Err(NodeDataError::NotAParent),
         };
 
-        child_map.retain(|_, id| id != permanent_id);
+        child_map.retain(|_, id| id.permanent_id() != permanent_id);
 
         Ok(())
     }
@@ -255,7 +283,7 @@ impl NodeData {
 }
 
 async fn encode_children<W: AsyncWrite + Unpin + Send>(
-    children: &HashMap<NodeName, PermanentId>,
+    children: &ChildMap,
     writer: &mut W,
 ) -> std::io::Result<usize> {
     let child_count = children.len();
@@ -271,7 +299,7 @@ async fn encode_children<W: AsyncWrite + Unpin + Send>(
     let mut written_bytes = child_count_bytes.len();
 
     let mut children = children.iter().collect::<Vec<_>>();
-    children.sort_by(|(_, a), (_, b)| a.cmp(b));
+    children.sort_by(|(_, a), (_, b)| a.permanent_id().cmp(b.permanent_id()));
 
     for (name, id) in children {
         written_bytes += name.encode(writer).await?;
@@ -281,7 +309,7 @@ async fn encode_children<W: AsyncWrite + Unpin + Send>(
     Ok(written_bytes)
 }
 
-fn parse_children(input: Stream) -> ParserResult<HashMap<NodeName, PermanentId>> {
+fn parse_children(input: Stream) -> ParserResult<ChildMap> {
     let (data_buf, children_count) = le_u16.parse_peek(input)?;
 
     let mut children = HashMap::new();
@@ -289,9 +317,9 @@ fn parse_children(input: Stream) -> ParserResult<HashMap<NodeName, PermanentId>>
 
     for _ in 0..children_count {
         let (remaining, child_name) = NodeName::parse(child_buf)?;
-        let (remaining, child_id) = PermanentId::parse(remaining)?;
+        let (remaining, child_entry) = ChildMapEntry::parse(remaining)?;
 
-        children.insert(child_name, child_id);
+        children.insert(child_name, child_entry);
 
         child_buf = remaining;
     }
@@ -302,11 +330,14 @@ fn parse_children(input: Stream) -> ParserResult<HashMap<NodeName, PermanentId>>
 #[derive(Debug, thiserror::Error)]
 pub enum NodeDataError {
     #[error("attempted to add child with a name that was already present")]
-    NameExists,
+    ChildNameExists,
 
     #[error("attempted to remove a child that was not present")]
-    NameMissing,
+    ChildNameMissing,
 
     #[error("non-parent node cannot have or interact with children")]
     NotAParent,
+
+    #[error("Passed in PermanentId does not refer to a valid child")]
+    ChildIdMissing,
 }


### PR DESCRIPTION
This PR incorporates the cid of a nodes children into the nodes data. It does this by changing the existing map of children from a `HashMap<NodeName, PermanentId>` to a `Hashmap<NodeName, ChildMapEntry>` where a child map entry has a `PermanentId` and a `CID`. 

With this change we now need to update that Cid. Nodes don't have a way to inspect other nodes so this is handled by the DriveInner. Using the same clan/dirty status that tracks child sizes. Marking nodes dirty now also marks their Cid dirty. 

Right now the total size of all of  nodes children is stored as one `u64` however after this change it might make sense to to also store a per-node size in the ChildMap. This would more tightly integrate the concepts of `size` and `cid` that both are dirty in the same circumstances and rely on the same sort of recursive propagation of data.