### PR TITLE
Automatically add platform key

### DIFF
--- a/src/api/platform/mod.rs
+++ b/src/api/platform/mod.rs
@@ -27,5 +27,4 @@ pub const PLATFORM_MAINTENANCE_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
 MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE00jlH0iG12Lq1tuCwom4ma2dwZ/56Oxf
 Yl0LDsPoeNDWOuFDBtjvJRQllusFrIpEKJY+nRLq+Px+dlqtKlL4yD/0IVRcqYt/
 9mdrZWJ4KqrEUuRnYtNiPeCrfiKRqfjA
------END PUBLIC KEY-----
-"#;
+-----END PUBLIC KEY-----"#;

--- a/src/api/platform/mod.rs
+++ b/src/api/platform/mod.rs
@@ -10,3 +10,22 @@ pub mod metadata;
 pub mod snapshots;
 
 pub use models::*;
+
+/// This is the public key used by the Banyan platform to access a filesystem's metadata. This is
+/// granted maintenance level privileges within the format which only allowed for knowledge of the
+/// other keys being present. It does not grant a view of the filesystem structure, attributes, or
+/// the data contents themselves.
+///
+/// When the CRDT and journaling system is in place, this will also grant access to knowledge about
+/// which blocks of data are associated with an individual update and which ones can be safely
+/// discarded.
+///
+/// This distinction allows deniability at the filesystem level of who can access the data (which
+/// Banyan will learn by being a minimal privilege party) while still providing the minimal
+/// information required to host and maintain versioned data over time.
+pub const PLATFORM_MAINTENANCE_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE00jlH0iG12Lq1tuCwom4ma2dwZ/56Oxf
+Yl0LDsPoeNDWOuFDBtjvJRQllusFrIpEKJY+nRLq+Px+dlqtKlL4yD/0IVRcqYt/
+9mdrZWJ4KqrEUuRnYtNiPeCrfiKRqfjA
+-----END PUBLIC KEY-----
+"#;

--- a/src/filesystem/drive/access.rs
+++ b/src/filesystem/drive/access.rs
@@ -112,6 +112,18 @@ impl DriveAccess {
         access.has_filesystem_key() && access.has_data_key()
     }
 
+    /// Cheks whether the requested actor is able to read maintenance related information from an
+    /// encrypted drive. This includes information such as which public keys are present and the
+    /// CIDs of the data blocks that are being added and removed.
+    pub fn has_maintenance_access(&self, actor_id: &ActorId) -> bool {
+        let access = match self.active_actor_access(actor_id) {
+            Some(a) => a,
+            None => return false,
+        };
+
+        access.has_maintenance_key()
+    }
+
     /// Checks whether the requested actor is able to read the the structure of the filesystem and
     /// the associated attributes with its contents. This does not check whether the actor is able
     /// to read data from files or associated data nodes. To check whether the Actor can read data

--- a/src/filesystem/drive/mod.rs
+++ b/src/filesystem/drive/mod.rs
@@ -136,6 +136,11 @@ impl Drive {
         Ok(written_bytes)
     }
 
+    pub async fn has_maintenance_access(&self, actor_id: &ActorId) -> bool {
+        let inner = self.inner.read().await;
+        inner.access().has_maintenance_access(actor_id)
+    }
+
     pub async fn has_read_access(&self, actor_id: &ActorId) -> bool {
         let inner = self.inner.read().await;
         inner.access().has_read_access(actor_id)

--- a/src/wasm/tomb_compat/mod.rs
+++ b/src/wasm/tomb_compat/mod.rs
@@ -74,17 +74,6 @@ impl TombCompat {
         Ok(())
     }
 
-    // appears to no longer be present, likely migrated to create_bucket_and_mount
-    //#[wasm_bindgen(js_name = createBucket)]
-    //pub async fn create_bucket(
-    //    &mut self,
-    //    name: String,
-    //    storage_class: String,
-    //    bucket_type: String,
-    //    public_key: CryptoKey,
-    //) -> BanyanFsResult<WasmBucket> {
-    //}
-
     // new transfered and checked,
     //
     // note(sstelfox): we already have the private key, and that gives us the public key. I'm

--- a/src/wasm/tomb_compat/wasm_mount.rs
+++ b/src/wasm/tomb_compat/wasm_mount.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use elliptic_curve::rand_core::CryptoRngCore;
 use futures::io::Cursor;
 use futures::StreamExt;
 
@@ -57,19 +58,7 @@ impl WasmMount {
         let drive = Drive::initialize_private_with_id(&mut rng, signing_key, filesystem_id)
             .map_err(|e| BanyanFsError::from(e.to_string()))?;
 
-        let access_mask = AccessMaskBuilder::maintenance()
-            .protected()
-            .build()
-            .map_err(|e| format!("failed to build maintenance access mask: {e}"))?;
-
-        let platform_public_key =
-            VerifyingKey::from_spki(crate::api::platform::PLATFORM_MAINTENANCE_KEY)
-                .map_err(|e| format!("failed to parse platform public key: {e}"))?;
-
-        drive
-            .authorize_key(&mut rng, platform_public_key, access_mask)
-            .await
-            .map_err(|e| format!("failed to authorize platform key: {e}"))?;
+        ensure_platform_key_present(&mut rng, &drive).await?;
 
         let mut mount = Self {
             wasm_client,
@@ -99,6 +88,11 @@ impl WasmMount {
         // in here indicating that an initial metadata hasn't be pushed but that is a weird failure
         // case. We should really enforce an initial metadata push during the bucket creation...
         let drive = try_load_drive(client, &drive_id, &metadata_id).await;
+
+        if let Some(d) = drive.as_ref() {
+            ensure_platform_key_present(&mut crypto_rng(), d).await?;
+        }
+
         let dirty = drive.is_none();
         let store = wasm_client.store();
 
@@ -584,11 +578,26 @@ async fn try_load_drive(client: &ApiClient, drive_id: &str, metadata_id: &str) -
     }
 }
 
-fn vec_to_js_array<T>(vec: Vec<T>) -> js_sys::Array
-where
-    T: Into<JsValue>,
-{
-    vec.into_iter().map(|x| x.into()).collect()
+async fn ensure_platform_key_present(
+    rng: &mut impl CryptoRngCore,
+    drive: &Drive,
+) -> BanyanFsResult<()> {
+    let pubkey = VerifyingKey::from_spki(crate::api::platform::PLATFORM_MAINTENANCE_KEY)
+        .map_err(|e| format!("failed to parse platform public key: {e}"))?;
+
+    if !drive.has_maintenance_access(&pubkey.actor_id()).await {
+        let access_mask = AccessMaskBuilder::maintenance()
+            .protected()
+            .build()
+            .map_err(|e| format!("failed to build maintenance access mask: {e}"))?;
+
+        drive
+            .authorize_key(rng, pubkey, access_mask)
+            .await
+            .map_err(|e| format!("failed to authorize platform key: {e}"))?;
+    }
+
+    Ok(())
 }
 
 fn parse_js_path(path_arr: js_sys::Array) -> BanyanFsResult<Vec<String>> {
@@ -611,4 +620,11 @@ fn parse_js_path(path_arr: js_sys::Array) -> BanyanFsResult<Vec<String>> {
     }
 
     Ok(strings)
+}
+
+fn vec_to_js_array<T>(vec: Vec<T>) -> js_sys::Array
+where
+    T: Into<JsValue>,
+{
+    vec.into_iter().map(|x| x.into()).collect()
 }


### PR DESCRIPTION
This solves a problem in production where the public keys are only visible to users who are party to the filesystem and retroactively will add the key to the filesystem for existing ones. What this doesn't solve, and I can't think of a good way to handle is adding local development keys.

So far the best idea I've come up with is dynamically embedding one using a `build.rs` script but that isn't that "dynamic" and it would need someway to either know the path in a specific development environment (such as via an environment variable). It's workable but I'd love some thoughts if anyone else has any.