### PR TITLE
Child Map holds children size

### DIFF
--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -303,6 +303,7 @@ impl DirectoryHandle {
         let mut inner_write = self.inner.write().await;
         let src_node_name = inner_write.by_id(src_node_id)?.name();
         let src_node_cid = inner_write.by_id(src_node_id)?.cid().await?;
+        let src_node_size = inner_write.by_id(src_node_id)?.size();
         let src_node_perm_id = inner_write.by_id(src_node_id)?.permanent_id();
         let src_parent_perm_id = inner_write.by_id(src_node_id)?.parent_id().ok_or(
             OperationError::InternalCorruption(src_node_id, "src node has no parent"),
@@ -328,7 +329,12 @@ impl DirectoryHandle {
         let dst_parent_node_perm_id = dst_parent_node.permanent_id();
 
         dst_parent_node
-            .add_child(new_dst_name.clone(), src_node_perm_id, src_node_cid)
+            .add_child(
+                new_dst_name.clone(),
+                src_node_perm_id,
+                src_node_cid,
+                src_node_size,
+            )
             .await?;
 
         let src_node = inner_write.by_id_mut(src_node_id).await?;

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -11,7 +11,6 @@ use crate::codec::crypto::AccessKey;
 use crate::codec::*;
 use crate::filesystem::drive::DriveAccess;
 use crate::filesystem::nodes::{Node, NodeBuilder, NodeId};
-use crate::prelude::nodes::NodeData;
 use crate::utils::std_io_err;
 
 use super::OperationError;
@@ -121,38 +120,30 @@ impl InnerDrive {
         // Pop elements from back and update their size and Cid
         while let Some(node_id) = node_list.pop() {
             // Because of the work above we can assume that once we get here all of a nodes children are up to date
-            let node = self.by_id(node_id)?;
 
-            // Update Size:
-            let new_children_size = node
-                .ordered_child_pids()
-                .iter()
-                .try_fold(0, |acc, child_pid| {
-                    self.by_perm_id(child_pid).map(|node| node.size() + acc)
-                })?;
             let node_mut = self
                 .by_id_mut_untracked(node_id)
                 .expect("We've already accessed this node immutably just above");
-            match node_mut.data_mut().await {
-                NodeData::Directory { children_size, .. } => *children_size = new_children_size,
-                _ => {}
-            }
 
-            // Update child CIDs
+            // Update child CIDs and sizes
             let child_pids = node_mut.data().ordered_child_pids();
-            let mut child_cids = Vec::new();
+            let mut child_data = Vec::new();
             for pid in child_pids {
-                child_cids.push((pid, self.by_perm_id_mut_untracked(&pid)?.cid().await?))
+                child_data.push((
+                    pid,
+                    self.by_perm_id_mut_untracked(&pid)?.cid().await?,
+                    self.by_perm_id_mut_untracked(&pid)?.size(),
+                ))
             }
 
             let node_mut = self
                 .by_id_mut_untracked(node_id)
                 .expect("We've already accessed this node immutably just above");
-            for child in child_cids {
+            for child in child_data {
                 node_mut
                     .data_mut()
                     .await
-                    .update_child_cid(&child.0, child.1)?;
+                    .update_child(&child.0, child.1, child.2)?;
             }
         }
         Ok(())
@@ -213,6 +204,7 @@ impl InnerDrive {
 
         let node = build_node(rng, node_id, parent_permanent_id, owner_id).await?;
         let cid = node.cid().await?;
+        let size = node.size();
 
         let name = node.name();
         let permanent_id = node.permanent_id();
@@ -222,7 +214,7 @@ impl InnerDrive {
         self.permanent_id_map.insert(permanent_id, node_id);
 
         let parent_node = self.by_perm_id_mut(&parent_permanent_id).await?;
-        parent_node.add_child(name, permanent_id, cid).await?;
+        parent_node.add_child(name, permanent_id, cid, size).await?;
 
         Ok(permanent_id)
     }

--- a/src/filesystem/drive/inner.rs
+++ b/src/filesystem/drive/inner.rs
@@ -120,10 +120,7 @@ impl InnerDrive {
         // Pop elements from back and update their size and Cid
         while let Some(node_id) = node_list.pop() {
             // Because of the work above we can assume that once we get here all of a nodes children are up to date
-
-            let node_mut = self
-                .by_id_mut_untracked(node_id)
-                .expect("We've already accessed this node immutably just above");
+            let node_mut = self.by_id_mut_untracked(node_id)?;
 
             // Update child CIDs and sizes
             let child_pids = node_mut.data().ordered_child_pids();
@@ -136,9 +133,7 @@ impl InnerDrive {
                 ))
             }
 
-            let node_mut = self
-                .by_id_mut_untracked(node_id)
-                .expect("We've already accessed this node immutably just above");
+            let node_mut = self.by_id_mut_untracked(node_id)?;
             for child in child_data {
                 node_mut
                     .data_mut()

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -95,8 +95,10 @@ impl Node {
         name: NodeName,
         child_id: PermanentId,
         child_cid: Cid,
+        child_size: u64,
     ) -> Result<(), NodeDataError> {
-        self.inner.add_child(name, child_id, child_cid)?;
+        self.inner
+            .add_child(name, child_id, child_cid, child_size)?;
         self.notify_of_change().await;
 
         Ok(())

--- a/src/filesystem/nodes/node_data/child_map.rs
+++ b/src/filesystem/nodes/node_data/child_map.rs
@@ -51,8 +51,9 @@ impl ChildMapEntry {
     ) -> std::io::Result<usize> {
         let mut bytes_written = self.permanent_id().encode(writer).await?;
         bytes_written += self.cid().encode(writer).await?;
-        writer.write_all(&self.size().to_le_bytes()).await?;
-        bytes_written += std::mem::size_of::<u64>();
+        let size_bytes = self.size().to_le_bytes();
+        writer.write_all(&size_bytes).await?;
+        bytes_written += size_bytes.len();
         Ok(bytes_written)
     }
 

--- a/src/filesystem/nodes/node_data/child_map.rs
+++ b/src/filesystem/nodes/node_data/child_map.rs
@@ -1,6 +1,7 @@
 use crate::codec::{ParserResult, Stream};
-use futures::io::AsyncWrite;
+use futures::{AsyncWrite, AsyncWriteExt};
 use std::collections::HashMap;
+use winnow::{binary::le_u64, Parser};
 
 use crate::{
     codec::{Cid, PermanentId},
@@ -12,11 +13,16 @@ pub(crate) type ChildMap = HashMap<NodeName, ChildMapEntry>;
 pub(crate) struct ChildMapEntry {
     permanent_id: PermanentId,
     cid: Cid,
+    size: u64,
 }
 
 impl ChildMapEntry {
-    pub fn new(permanent_id: PermanentId, cid: Cid) -> Self {
-        Self { permanent_id, cid }
+    pub fn new(permanent_id: PermanentId, cid: Cid, size: u64) -> Self {
+        Self {
+            permanent_id,
+            cid,
+            size,
+        }
     }
 
     pub fn permanent_id(&self) -> &PermanentId {
@@ -27,20 +33,33 @@ impl ChildMapEntry {
         &self.cid
     }
 
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
     pub fn set_cid(&mut self, cid: Cid) {
         self.cid = cid;
+    }
+
+    pub fn set_size(&mut self, size: u64) {
+        self.size = size;
     }
 
     pub async fn encode<W: AsyncWrite + Unpin + Send>(
         &self,
         writer: &mut W,
     ) -> std::io::Result<usize> {
-        Ok(self.permanent_id().encode(writer).await? + self.cid().encode(writer).await?)
+        let mut bytes_written = self.permanent_id().encode(writer).await?;
+        bytes_written += self.cid().encode(writer).await?;
+        writer.write_all(&self.size().to_le_bytes()).await?;
+        bytes_written += std::mem::size_of::<u64>();
+        Ok(bytes_written)
     }
 
     pub fn parse(input: Stream) -> ParserResult<Self> {
         let (input, id) = PermanentId::parse(input)?;
         let (input, cid) = Cid::parse(input)?;
-        Ok((input, Self::new(id, cid)))
+        let (input, size) = le_u64.parse_peek(input)?;
+        Ok((input, Self::new(id, cid, size)))
     }
 }


### PR DESCRIPTION
Rework ChildMap Entry to hold a size of each child. This allows us to not store the summed-up children size as part of the NodeData. Instead each time we want the summed up size we need to do the addition there, this is cheap though. 

As part of the change Files are now properly including the size of their associated data, where before only directories were keeping track of the size of their children.

There is also a subtle distinction in how the cid and size of a node are offered. A node keeps track of a dirty state of its own cid, so there are some situations where asking for the cid of node will cause a recursive walk of cid calculations of its ancestors. Where the size of a node is only ever changed or set during the drive cleaning process. So if you ask the size of a node while the drive is dirty you could get an out of date answer. The drive cleaning process is careful to sequence sizes computation of the nodes in the correct order so that the size is accurate by the end of the process.