### PR TITLE
Replacing OnceCell with OnceLock

### DIFF
--- a/src/wasm/tomb_compat/wasm_mount.rs
+++ b/src/wasm/tomb_compat/wasm_mount.rs
@@ -78,7 +78,7 @@ impl WasmMount {
     }
 
     pub(crate) async fn pull(bucket: WasmBucket, wasm_client: TombCompat) -> BanyanFsResult<Self> {
-        let &mut client = wasm_client.client();
+        let client = wasm_client.client();
         let drive_id = bucket.id();
 
         let current_metadata = platform::metadata::get_current(client, &drive_id).await?;

--- a/src/wasm/tomb_compat/wasm_mount.rs
+++ b/src/wasm/tomb_compat/wasm_mount.rs
@@ -78,7 +78,7 @@ impl WasmMount {
     }
 
     pub(crate) async fn pull(bucket: WasmBucket, wasm_client: TombCompat) -> BanyanFsResult<Self> {
-        let client = wasm_client.client();
+        let &mut client = wasm_client.client();
         let drive_id = bucket.id();
 
         let current_metadata = platform::metadata::get_current(client, &drive_id).await?;


### PR DESCRIPTION
Replacing `OnceCell` with `OnceLock`, since (due to lack of `Sync`) it breaks `Send` for anything that is holding an instance of ApiClient and wants to use `&self` in an async context.