### PR TITLE
Exposing some structs and methods

### DIFF
--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -5,10 +5,10 @@ mod expiring_token;
 mod platform_token;
 mod storage_host_auth;
 mod traits;
+pub(crate) mod utils;
 
 pub use error::ApiClientError;
-
-pub(crate) mod utils;
+pub use utils::VecStream;
 
 pub(crate) use api_auth::ApiAuth;
 pub(crate) use direct_response::DirectResponse;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,4 +9,4 @@ pub mod storage_host;
 
 pub(crate) mod client;
 
-pub use client::ApiClient;
+pub use client::{ApiClient, VecStream};

--- a/src/api/platform/metadata/push_request.rs
+++ b/src/api/platform/metadata/push_request.rs
@@ -172,19 +172,19 @@ pub struct PushResponse {
 
 #[allow(dead_code)]
 impl PushResponse {
-    pub(crate) fn id(&self) -> ApiMetadataId {
+    pub fn id(&self) -> ApiMetadataId {
         self.id.clone()
     }
 
-    pub(crate) fn state(&self) -> &str {
+    pub fn state(&self) -> &str {
         &self.state
     }
 
-    pub(crate) fn storage_authorization(&self) -> Option<&str> {
+    pub fn storage_authorization(&self) -> Option<&str> {
         self.storage_authorization.as_deref()
     }
 
-    pub(crate) fn storage_host(&self) -> Option<Url> {
+    pub fn storage_host(&self) -> Option<Url> {
         self.storage_host
             .as_deref()
             .and_then(|s| Url::parse(s).ok())

--- a/src/codec/filesystem/mod.rs
+++ b/src/codec/filesystem/mod.rs
@@ -6,4 +6,4 @@ mod node_kind;
 pub use block_kind::BlockKind;
 pub use directory_permissions::DirectoryPermissions;
 pub use file_permissions::FilePermissions;
-pub(crate) use node_kind::NodeKind;
+pub use node_kind::NodeKind;

--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -33,7 +33,7 @@ pub struct DirectoryHandle {
 
 impl DirectoryHandle {
 
-    pub async fn to_entry(&self) -> Result<DirectoryEntry, OperationError> {
+    pub async fn entry(&self) -> Result<DirectoryEntry, OperationError> {
         let inner_read = self.inner.read().await;
         let root = inner_read.root_node()?;
         DirectoryEntry::try_from(root)

--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -32,6 +32,13 @@ pub struct DirectoryHandle {
 }
 
 impl DirectoryHandle {
+
+    pub async fn to_entry(&self) -> Result<DirectoryEntry, OperationError> {
+        let inner_read = self.inner.read().await;
+        let root = inner_read.root_node()?;
+        DirectoryEntry::try_from(root)
+    }
+
     /// Allows traversing the filesystem both up and down. Does not allow invalid character in any
     /// of the path elements (primarily "/"). Will report an error if you attempt to traverse above
     /// the root of the filesystem or into/through an invalid node type.

--- a/src/filesystem/drive/mod.rs
+++ b/src/filesystem/drive/mod.rs
@@ -243,15 +243,6 @@ impl Drive {
 
         Ok(root_cid)
     }
-
-    pub async fn root_entry(&self) -> Result<DirectoryEntry, OperationError> {
-        let inner_read = self.inner.read().await;
-
-        let root_perm_id = inner_read.root_pid();
-        let root_node = inner_read.by_perm_id(&root_perm_id)?;
-
-        DirectoryEntry::try_from(root_node)
-    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/filesystem/nodes/mod.rs
+++ b/src/filesystem/nodes/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use cid_cache::CidCache;
 pub(crate) use node_builder::{NodeBuilder, NodeBuilderError};
 
 pub(crate) use node_data::{NodeData, NodeDataError};
-pub(crate) use node_name::{NodeName, NodeNameError};
+pub use node_name::{NodeName, NodeNameError};
 
 use std::collections::HashMap;
 use std::io::{Error as StdError, ErrorKind as StdErrorKind};


### PR DESCRIPTION
- Exposing `VecStream` for streaming data
- Exposing `NodeKind` and `NodeName` for matching 
- Exposing `PushResponse` fields, since it's an API response object
- Added conversion to `DirectoryEntry` from `DirectoryHandle`