### PR TITLE
Handles from IDs

### DIFF
--- a/src/filesystem/drive/directory_handle.rs
+++ b/src/filesystem/drive/directory_handle.rs
@@ -32,11 +32,11 @@ pub struct DirectoryHandle {
 }
 
 impl DirectoryHandle {
-
+    /// Retrieves the [`DirectoryEntry`] for the current working directory.
     pub async fn entry(&self) -> Result<DirectoryEntry, OperationError> {
         let inner_read = self.inner.read().await;
-        let root = inner_read.root_node()?;
-        DirectoryEntry::try_from(root)
+        let node = inner_read.by_id(self.cwd_id)?;
+        DirectoryEntry::try_from(node)
     }
 
     /// Allows traversing the filesystem both up and down. Does not allow invalid character in any


### PR DESCRIPTION
Some requested helper functions for quick access to specific entries and directories as well as a fix for the conversion between directory handles and their own entry.