### PR TITLE
Release builds are currently failing

### DIFF
--- a/src/codec/parser/mod.rs
+++ b/src/codec/parser/mod.rs
@@ -11,19 +11,11 @@ use winnow::Partial;
 
 pub type Stream<'a> = Partial<&'a [u8]>;
 
-#[cfg(debug_assertions)]
 pub type CompleteParserResult<'a, T> =
     winnow::IResult<&'a [u8], T, winnow::error::ContextError<&'a [u8]>>;
 
-#[cfg(debug_assertions)]
 pub type ParserResult<'a, T> =
     winnow::IResult<Stream<'a>, T, winnow::error::ContextError<Stream<'a>>>;
-
-#[cfg(not(debug_assertions))]
-pub type CompleteParserResult<'a, T> = winnow::IResult<&'a [u8], T>;
-
-#[cfg(not(debug_assertions))]
-pub type ParserResult<'a, T> = winnow::IResult<Stream<'a>, T>;
 
 pub type StateResult<T, E> = Result<ProgressType<T>, E>;
 


### PR DESCRIPTION
This conditional type definition produced types which were incompatible in different build settings. 
Maybe this isn't the solution we're actually looking for, but something should change here. 